### PR TITLE
fix(smtp): correct shutdown drain order and close review gaps

### DIFF
--- a/charts/chaski/templates/NOTES.txt
+++ b/charts/chaski/templates/NOTES.txt
@@ -16,7 +16,11 @@ chaski {{ .Chart.AppVersion }} is deployed as {{ include "chaski.fullname" . }} 
 
 📧 SMTP ingestion is enabled on port {{ .Values.config.smtpPort }}. Send mail to
    <route>@{{ .Values.config.smtpHostname }} (the recipient localpart selects the route).
-   {{- if not .Values.auth.smtpAuth }}
+   {{- if and .Values.auth.smtpAuth .Values.auth.existingSecret }}
+   ⚠  auth.smtpAuth is set but IGNORED because auth.existingSecret is in use; the
+      chart will not wire CHASKI_SMTP_AUTH. Supply it via envFrom/extraEnv from your
+      Secret, otherwise SMTP AUTH stays OFF.
+   {{- else if not .Values.auth.smtpAuth }}
    AUTH is off and there is no TLS, so keep this listener on a trusted network.
    {{- end }}
 {{- end }}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,18 +40,19 @@ func TestLoadDefaults(t *testing.T) {
 
 func TestLoadErrors(t *testing.T) {
 	tests := map[string]map[string]string{
-		"invalid log level": {"CHASKI_LOG_LEVEL": "bogus"},
-		"port out of range": {"CHASKI_PORT": "0"},
-		"metrics port high": {"CHASKI_METRICS_PORT": "70000"},
-		"ports collide":     {"CHASKI_PORT": "9000", "CHASKI_METRICS_PORT": "9000"},
-		"bad log format":    {"CHASKI_LOG_FORMAT": "yaml"},
-		"negative body":     {"CHASKI_MAX_BODY_BYTES": "-1"},
-		"zero attempts":     {"CHASKI_RETRY_ATTEMPTS": "0"},
-		"zero timeout":      {"CHASKI_REQUEST_TIMEOUT": "0s"},
-		"smtp vs http port": {"CHASKI_SMTP_ENABLED": "true", "CHASKI_SMTP_PORT": "8080"},
-		"smtp vs metrics":   {"CHASKI_SMTP_ENABLED": "true", "CHASKI_SMTP_PORT": "8081"},
-		"smtp zero rcpts":   {"CHASKI_SMTP_ENABLED": "true", "CHASKI_SMTP_MAX_RECIPIENTS": "0"},
-		"smtp bad auth":     {"CHASKI_SMTP_AUTH": "missingcolon"},
+		"invalid log level":  {"CHASKI_LOG_LEVEL": "bogus"},
+		"port out of range":  {"CHASKI_PORT": "0"},
+		"metrics port high":  {"CHASKI_METRICS_PORT": "70000"},
+		"ports collide":      {"CHASKI_PORT": "9000", "CHASKI_METRICS_PORT": "9000"},
+		"bad log format":     {"CHASKI_LOG_FORMAT": "yaml"},
+		"negative body":      {"CHASKI_MAX_BODY_BYTES": "-1"},
+		"zero attempts":      {"CHASKI_RETRY_ATTEMPTS": "0"},
+		"zero timeout":       {"CHASKI_REQUEST_TIMEOUT": "0s"},
+		"smtp vs http port":  {"CHASKI_SMTP_ENABLED": "true", "CHASKI_SMTP_PORT": "8080"},
+		"smtp vs metrics":    {"CHASKI_SMTP_ENABLED": "true", "CHASKI_SMTP_PORT": "8081"},
+		"smtp zero rcpts":    {"CHASKI_SMTP_ENABLED": "true", "CHASKI_SMTP_MAX_RECIPIENTS": "0"},
+		"smtp zero msgbytes": {"CHASKI_SMTP_ENABLED": "true", "CHASKI_SMTP_MAX_MESSAGE_BYTES": "0"},
+		"smtp bad auth":      {"CHASKI_SMTP_AUTH": "missingcolon"},
 	}
 	for name, envs := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/smtp/email.go
+++ b/internal/smtp/email.go
@@ -64,6 +64,7 @@ func parseEmail(raw []byte, log *slog.Logger) message {
 			break
 		}
 		if err != nil && !gomsg.IsUnknownCharset(err) {
+			log.Warn("smtp: stopped reading message parts; remaining content dropped", "error", err)
 			break
 		}
 		ih, ok := p.Header.(*gomail.InlineHeader)

--- a/internal/smtp/smtp.go
+++ b/internal/smtp/smtp.go
@@ -53,8 +53,8 @@ type Server struct {
 // network); credentials therefore travel in the clear, so keep the listener
 // internal.
 func New(cfg *config.Config, engine *relay.Engine, log *slog.Logger, observe Observer) *Server {
-	// baseCtx parents every in-flight relay so Shutdown can cancel work that is
-	// mid-flight rather than letting it run detached past the drain window.
+	// baseCtx parents every in-flight relay so that, once the drain window
+	// closes, any relay still running is cancelled rather than left detached.
 	baseCtx, cancel := context.WithCancel(context.Background())
 	be := &backend{
 		engine:       engine,
@@ -87,13 +87,14 @@ func (s *Server) ListenAndServe() error {
 	return nil
 }
 
-// Shutdown cancels in-flight relays and drains the listener (nil-safe, like the
-// HTTP drain).
+// Shutdown drains the listener, letting in-flight relays finish within ctx's
+// deadline (like the HTTP drain), then cancels baseCtx as a backstop for any
+// relay still running once the window closes. Nil-safe.
 func (s *Server) Shutdown(ctx context.Context) {
 	if s == nil {
 		return
 	}
-	s.cancel()
+	defer s.cancel()
 	_ = s.inner.Shutdown(ctx)
 }
 

--- a/internal/smtp/smtp_test.go
+++ b/internal/smtp/smtp_test.go
@@ -25,24 +25,33 @@ type fakeNotifier struct {
 	err    error // when set, Send fails (drives a relay error)
 }
 
-func (f *fakeNotifier) Send(_ context.Context, _, body, _ string, _ map[string]string) error {
+func (f *fakeNotifier) Send(_ context.Context, targetURL, body, _ string, _ map[string]string) error {
 	f.mu.Lock()
 	f.calls++
 	f.bodies = append(f.bodies, body)
 	err := f.err
 	f.mu.Unlock()
+	if strings.Contains(targetURL, "fail") { // the "broken" route's target always errors
+		return context.DeadlineExceeded
+	}
 	return err
 }
 
 func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
 
 const routeYAML = `
-targets: { po: { apprise: { url: 'pover://u@t/' } } }
+targets:
+  po: { apprise: { url: 'pover://u@t/' } }
+  failtarget: { apprise: { url: 'pover://u@fail/' } }
 routes:
   alerts:
     target: po
     whenExpr: 'payload.subject != ""'
     title: '{{ .payload.subject }}'
+    message: '{{ .payload.body }}'
+  broken:
+    target: failtarget
+    whenExpr: 'payload.subject != ""'
     message: '{{ .payload.body }}'
 `
 
@@ -144,6 +153,18 @@ func TestParseEmailDecodesSubjectAndSkipsAttachment(t *testing.T) {
 	}
 }
 
+func TestParseEmailNonMIMEFallback(t *testing.T) {
+	// A blob with no header/body separator fails MIME parsing, exercising the
+	// net/mail parsePlain fallback (whole body becomes text).
+	m := parseEmail([]byte("not an email, no headers at all"), discardLog())
+	if !strings.Contains(m.text, "not an email") {
+		t.Errorf("text = %q, want the raw blob via the parsePlain fallback", m.text)
+	}
+	if m.from != "" || m.subject != "" {
+		t.Errorf("from=%q subject=%q, want empty for a headerless blob", m.from, m.subject)
+	}
+}
+
 func TestSessionRcptResolvesAndRejects(t *testing.T) {
 	s := &session{be: testBackend(t, &fakeNotifier{}), authed: true}
 	if err := s.Rcpt("alerts@chaski", nil); err != nil {
@@ -191,6 +212,23 @@ func TestSessionDedupesRepeatRcpts(t *testing.T) {
 	}
 	if n.calls != 1 {
 		t.Errorf("notifier calls = %d, want 1 (no fan-out amplification)", n.calls)
+	}
+}
+
+func TestSessionDataMixedOutcomeAccepts(t *testing.T) {
+	// alerts relays OK, broken's downstream always fails. Because one recipient
+	// was delivered, the whole message is accepted (250/nil) so a retry can't
+	// duplicate the delivered one. This pins `failed && !delivered`.
+	n := &fakeNotifier{}
+	s := &session{be: testBackend(t, n), authed: true}
+	if err := s.Rcpt("alerts@chaski", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Rcpt("broken@chaski", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Data(strings.NewReader("Subject: x\r\n\r\nbody")); err != nil {
+		t.Fatalf("Data = %v, want nil (250) when one recipient was delivered", err)
 	}
 }
 


### PR DESCRIPTION
Follow-up to a second adversarial review of the merged SMTP ingestion feature ([#5](https://github.com/home-operations/chaski/pull/5)). The review re-examined the fix code from the first pass and found one real bug plus some test/observability gaps.

## Bug

- **Shutdown aborted in-flight mail at t=0.** The first review asked that in-flight relays be cancellable on shutdown rather than left detached; that fix over-corrected by calling `cancel()` *before* `inner.Shutdown(ctx)`, so the shared `baseCtx` was cancelled immediately and any relay mid-send returned `RelayError` instead of finishing within the drain window (the inverse of the HTTP path). Now `Shutdown` drains first and `cancel()` is a `defer`red post-drain backstop, so in-flight mail completes within `ShutdownTimeout` and only work outliving the window is cancelled.

## Tests (the gaps the review flagged)

- **Multi-recipient mixed outcome**: a message to one route that delivers and one that fails now asserts a 250 (not 451), pinning the `failed && !delivered` reply logic — a `&&`→`||` regression previously kept the suite green.
- **parsePlain fallback**: was 0% covered (the existing "Plain" test actually drives the MIME path); added a non-MIME blob case.
- **`SMTPMaxMessageBytes >= 1` guard**: added the missing `=0` validation case.

## Chart

- NOTES.txt now warns when `auth.smtpAuth` is set but **ignored** because `auth.existingSecret` is in use (supply `CHASKI_SMTP_AUTH` via `envFrom`). It was silent in exactly that case, which could mask an unauthenticated listener.

## Observability

- `parseEmail` now warns on a structural `NextPart` error too, matching the existing part-body truncation warning (the doc comment promised truncation is logged).

Not changed: the "truncated body relayed as 250" case stays warn-only by design — a decode failure is permanent, so a 451 retry would loop forever.

Verified: `go test -race ./...`, `golangci-lint` (0 issues), `go vet`, `gofmt`, `helm lint`, `helm unittest`, `generate-check`, and both NOTES branches render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)