### PR TITLE
fix(chart): make the NOTES quickstart curl runnable as printed

### DIFF
--- a/charts/chaski/templates/NOTES.txt
+++ b/charts/chaski/templates/NOTES.txt
@@ -25,12 +25,21 @@ chaski {{ .Chart.AppVersion }} is deployed as {{ include "chaski.fullname" . }} 
    {{- end }}
 {{- end }}
 
-Send a webhook from inside the cluster (replace the route + token):
+Send a webhook from inside the cluster (replace <route>):
+{{- if or .Values.auth.webhookToken .Values.auth.existingSecret }}
 
+  TOKEN=$(kubectl -n {{ .Release.Namespace }} get secret {{ .Values.auth.existingSecret | default (include "chaski.fullname" .) }} -o jsonpath='{.data.{{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecretKey }}{{ else }}token{{ end }}}' | base64 -d)
   kubectl -n {{ .Release.Namespace }} run chaski-curl --rm -it --restart=Never --image=curlimages/curl -- \
     curl -fsS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
       --data '{"status":"firing"}' \
       "http://{{ include "chaski.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/notify/<route>?dryRun=1"
+{{- else }}
+
+  kubectl -n {{ .Release.Namespace }} run chaski-curl --rm -it --restart=Never --image=curlimages/curl -- \
+    curl -fsS -X POST -H "Content-Type: application/json" \
+      --data '{"status":"firing"}' \
+      "http://{{ include "chaski.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/notify/<route>?dryRun=1"
+{{- end }}
 
 Validate the config (the same checks chaski runs at boot):
 


### PR DESCRIPTION
The Helm `NOTES.txt` quickstart always printed `-H "Authorization: Bearer $TOKEN"` with a literal `<route>`, even though token auth is **off by default** and `$TOKEN` was never defined — so the first command a new operator copy-pastes fails.

Now branches on auth state:
- **auth off** (default): no `Authorization` header.
- **auth on** (`webhookToken` or `existingSecret`): derives `TOKEN=$(kubectl get secret … -o jsonpath=… | base64 -d)` first, so `$TOKEN` is real.

Verified both branches render via `helm install --dry-run`; `helm lint` + `helm unittest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)