### PR TITLE
feat(relay): make the why-didn't-it-fire loop answerable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ curl -X POST http://localhost:8080/notify/alertmanager \
 ```
 
 Append `?dryRun=1` to preview the matched targets and rendered fields without
-sending. Check a config before deploying it (the same checks the server runs at
-boot):
+sending — including `"fired": false` when the `whenExpr` gate doesn't match, so
+you can see *why* a route wouldn't act. Every response also carries an
+`X-Chaski-Result` header (`relayed`, `skipped:gate`, `skipped:no_targets`,
+`render_error`, …) so the outcome is visible even on a bodyless status. Check a
+config before deploying it (the same checks the server runs at boot):
 
 ```sh
 chaski validate -c ./chaski.yaml

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -195,6 +195,7 @@ func (k Kind) String() string {
 type Result struct {
 	Status  int
 	Kind    Kind
+	Reason  string           // low-cardinality sub-reason for a Skipped result: "gate" or "no_targets"
 	Plan    *Plan            // set for a dry run
 	Err     error            // gate/render/relay error (for logging)
 	Dropped map[string]error // optional fields dropped at render (for logging)
@@ -212,7 +213,12 @@ func (r *Route) Handle(ctx context.Context, in Input) Result {
 		return Result{Status: http.StatusInternalServerError, Kind: GateError, Err: err}
 	}
 	if !fired {
-		return Result{Status: r.skipState, Kind: Skipped}
+		// A dry run still answers "why" — return a plan marked not-fired rather
+		// than a bodyless skip, since a false gate is the most common non-action.
+		if in.DryRun {
+			return Result{Status: http.StatusOK, Kind: DryRunned, Plan: &Plan{Route: r.name, Fired: false}}
+		}
+		return Result{Status: r.skipState, Kind: Skipped, Reason: "gate"}
 	}
 
 	rr, err := r.renderAll(in)
@@ -229,7 +235,7 @@ func (r *Route) Handle(ctx context.Context, in Input) Result {
 		return Result{Status: http.StatusBadGateway, Kind: RelayError, Err: err, Dropped: rr.dropped}
 	}
 	if sent == 0 {
-		return Result{Status: r.skipState, Kind: Skipped, Dropped: rr.dropped}
+		return Result{Status: r.skipState, Kind: Skipped, Reason: "no_targets", Dropped: rr.dropped}
 	}
 	return Result{Status: r.okStatus, Kind: Relayed, Dropped: rr.dropped}
 }

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -84,8 +84,30 @@ func TestGateSkips(t *testing.T) {
 	if res.Kind != relay.Skipped || res.Status != 204 {
 		t.Errorf("kind=%v status=%d, want Skipped 204", res.Kind, res.Status)
 	}
+	if res.Reason != "gate" {
+		t.Errorf("skip reason = %q, want gate", res.Reason)
+	}
 	if fn.calls != 0 {
 		t.Errorf("notifier called %d times on a skip", fn.calls)
+	}
+}
+
+func TestDryRunGateFalseReturnsPlan(t *testing.T) {
+	fn := &fakeNotifier{}
+	r := route(t, engine(t, apprise1, fn))
+
+	res := handle(r, map[string]any{"status": "resolved"}, true) // gate is false
+	if res.Kind != relay.DryRunned || res.Status != 200 || res.Plan == nil {
+		t.Fatalf("kind=%v status=%d plan=%v, want DryRunned 200 with a plan", res.Kind, res.Status, res.Plan)
+	}
+	if res.Plan.Fired {
+		t.Error("Plan.Fired = true, want false for a gate-false dry run")
+	}
+	if len(res.Plan.Targets) != 0 {
+		t.Errorf("Plan.Targets = %+v, want empty when the gate is false", res.Plan.Targets)
+	}
+	if fn.calls != 0 {
+		t.Errorf("gate-false dry run sent %d notifications", fn.calls)
 	}
 }
 
@@ -130,6 +152,9 @@ routes:
 	res := handle(r, map[string]any{}, false)
 	if res.Kind != relay.Skipped || fn.calls != 0 {
 		t.Errorf("empty apprise body: kind=%v calls=%d, want Skipped 0", res.Kind, fn.calls)
+	}
+	if res.Reason != "no_targets" {
+		t.Errorf("skip reason = %q, want no_targets", res.Reason)
 	}
 }
 

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -91,14 +91,31 @@ func (s *Server) handleNotify(w http.ResponseWriter, r *http.Request) {
 	})
 	s.observeRelay(r.PathValue("route"), res)
 
+	// A debug breadcrumb on every response: the outcome, with the skip sub-reason
+	// (gate vs no_targets) that the bare status code can't convey.
+	w.Header().Set("X-Chaski-Result", resultLabel(res))
+
 	switch {
 	case res.Plan != nil:
 		writeJSON(w, res.Status, res.Plan)
+	case (res.Kind == relay.GateError || res.Kind == relay.RenderError) && res.Err != nil:
+		// Operator-fault: surface the cause. These carry no payload body or target
+		// credentials (unlike a relay/502 error, which stays generic below).
+		writeError(w, res.Status, res.Err.Error())
 	case res.Status >= http.StatusInternalServerError:
 		writeError(w, res.Status, http.StatusText(res.Status))
 	default:
 		w.WriteHeader(res.Status)
 	}
+}
+
+// resultLabel renders a relay outcome for the X-Chaski-Result header, appending
+// the sub-reason for low-information kinds (e.g. "skipped:gate").
+func resultLabel(res relay.Result) string {
+	if res.Reason != "" {
+		return res.Kind.String() + ":" + res.Reason
+	}
+	return res.Kind.String()
 }
 
 // tokenOK constant-time compares the inbound token against CHASKI_WEBHOOK_TOKEN.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -181,6 +181,64 @@ func TestDryRunReturnsPlanWithoutSending(t *testing.T) {
 	}
 }
 
+func TestResultHeader(t *testing.T) {
+	srv := newServer(engineWithRoute(t, &fakeNotifier{}), "")
+
+	rec := do(srv, http.MethodPost, "/notify/alertmanager", `{"status":"firing"}`, map[string]string{"Content-Type": jsonCT})
+	if got := rec.Header().Get("X-Chaski-Result"); got != "relayed" {
+		t.Errorf("relayed header = %q, want relayed", got)
+	}
+	rec = do(srv, http.MethodPost, "/notify/alertmanager", `{"status":"resolved"}`, map[string]string{"Content-Type": jsonCT})
+	if got := rec.Header().Get("X-Chaski-Result"); got != "skipped:gate" {
+		t.Errorf("gate-false header = %q, want skipped:gate", got)
+	}
+}
+
+func TestDryRunGateFalseReturnsPlan(t *testing.T) {
+	srv := newServer(engineWithRoute(t, &fakeNotifier{}), "")
+	rec := do(srv, http.MethodPost, "/notify/alertmanager?dryRun=1", `{"status":"resolved"}`, map[string]string{"Content-Type": jsonCT})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (gate-false dry run still previews)", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"fired":false`) {
+		t.Errorf("gate-false dry-run body = %s, want fired:false", rec.Body.String())
+	}
+}
+
+func TestRenderErrorSurfacesCause(t *testing.T) {
+	const y = `
+targets: { po: { apprise: { url: 'pover://u@t/' } } }
+routes:
+  r: { target: po, message: '{{ .payload.x.Bad }}' }
+`
+	file := filepath.Join(t.TempDir(), "c.yaml")
+	if err := os.WriteFile(file, []byte(y), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rc, err := config.LoadRouteConfig(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, err := relay.Build(rc, &config.Config{RetryAttempts: 1, RetryBackoff: time.Millisecond}, relay.Options{Notifier: &fakeNotifier{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := newServer(e, "")
+
+	rec := do(srv, http.MethodPost, "/notify/r", `{"x":"scalar"}`, map[string]string{"Content-Type": jsonCT})
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "message") || strings.Contains(body, "Internal Server Error") {
+		t.Errorf("500 body = %s, want the render cause (not the generic text)", body)
+	}
+	if got := rec.Header().Get("X-Chaski-Result"); got != "render_error" {
+		t.Errorf("header = %q, want render_error", got)
+	}
+}
+
 func TestUnsupportedContentTypeIs400(t *testing.T) {
 	srv := newServer(engineWithRoute(t, &fakeNotifier{}), "")
 	rec := do(srv, http.MethodPost, "/notify/alertmanager", "hello", map[string]string{"Content-Type": "text/plain"})


### PR DESCRIPTION
From the UX audit: a relay operators most-common question is "I sent a webhook and nothing happened — why?" Today that is hard to answer. Three focused improvements:

## 1. Dry-run previews a false gate
`?dryRun=1` returned a bodyless `204` when the `whenExpr` gate was false — the single most common non-action — telling the operator nothing. The `Plan.Fired` field existed in the JSON contract but was **unreachable**. Now a gate-false dry run responds `200` with `{"route":…,"fired":false,"targets":[]}`, so you can see *why* a route would not act.

## 2. `X-Chaski-Result` header on every response
The two skip cases (gate false vs all-targets-empty) were byte-identical `204`s. Every response now carries `X-Chaski-Result`: `relayed`, `skipped:gate`, `skipped:no_targets`, `dryrun`, `render_error`, etc. — the outcome is visible even when the body is empty.

## 3. Actionable 5xx body
A gate/render fault returned `{"error":"Internal Server Error"}`, forcing a log dig. The cause is already in `res.Err`, so it is now surfaced in the body (e.g. `message: map has no entry for key "foo"`). Scoped to gate/render (500) faults only — **relay (502) errors stay generic** so a target URL never leaks.

Tests: gate-false dry-run plan (relay + server), skip-reason on both skip paths, the result header, and the surfaced render cause. `go test -race ./...`, `golangci-lint` (0), `gofmt`, `generate-check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)