### PR TITLE
fix(render): isolate field templates from snippet namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,10 +237,12 @@ routes:
     title: '{{ include "label" . }} audit: {{ .payload.action }}'
 ```
 
-Both routes render `[CRITICAL] …` from the one `label` snippet. An undefined
-`{{ template "typo" . }}` fails at boot / `chaski validate`; a malformed snippet
-fails to compile. `whenExpr` is CEL, so snippets don't apply there — only to the
-Go-template fields.
+Both routes render `[CRITICAL] …` from the one `label` snippet. A malformed
+snippet fails at boot / `chaski validate`, but an undefined `{{ template "typo"
+. }}` reference parses cleanly and only faults at render (the route returns 500) — run `chaski validate --payload sample.json` to exercise the templates
+before deploy. A snippet must not reference itself (directly or through a
+cycle); like Helm's `include`, a self-reference recurses without limit. `whenExpr`
+is CEL, so snippets don't apply there — only to the Go-template fields.
 
 ## SMTP ingestion
 

--- a/cmd/chaski/validate.go
+++ b/cmd/chaski/validate.go
@@ -145,7 +145,7 @@ func printSummary(w io.Writer, path string, rc *config.RouteConfig) {
 	// Writing the summary to stdout can't meaningfully fail; discard the result.
 	p := func(format string, a ...any) { _, _ = fmt.Fprintf(w, format, a...) }
 
-	p("ok: %s — %d route(s), %d target(s)\n", path, len(rc.Routes), len(rc.Targets))
+	p("ok: %s — %d route(s), %d target(s), %d template(s)\n", path, len(rc.Routes), len(rc.Targets), len(rc.Templates))
 	for _, name := range slices.Sorted(maps.Keys(rc.Routes)) {
 		r := rc.Routes[name]
 		p("  route %-24s (%s) → %v\n", name, r.Source, []string(r.Target))
@@ -153,5 +153,8 @@ func printSummary(w io.Writer, path string, rc *config.RouteConfig) {
 	for _, name := range slices.Sorted(maps.Keys(rc.Targets)) {
 		t := rc.Targets[name]
 		p("  target %-23s (%s) [%s]\n", name, t.Source, t.Kind())
+	}
+	for _, name := range slices.Sorted(maps.Keys(rc.Templates)) {
+		p("  template %-21s (%s)\n", name, rc.TemplateSource(name))
 	}
 }

--- a/internal/config/routes.go
+++ b/internal/config/routes.go
@@ -23,6 +23,13 @@ type RouteConfig struct {
 	templateSources map[string]string `yaml:"-"`
 }
 
+// TemplateSource returns the fragment file a named snippet was loaded from, or
+// "" if there is no such snippet. It exposes the loader's provenance for the
+// validate summary, mirroring Route.Source / Target.Source.
+func (rc *RouteConfig) TemplateSource(name string) string {
+	return rc.templateSources[name]
+}
+
 // Route gates an inbound webhook with a CEL expression and renders the fields
 // that are relayed to its target(s). whenExpr is the only CEL field; title,
 // message, and the params/headers values are Go templates evaluated per request.

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -59,9 +59,20 @@ type Set struct {
 	base *template.Template // holds the snippets; cloned per compiled field
 }
 
+// Reserved template names. rootName is the base/holder template (never
+// executed); fieldName is the name every field body is parsed under. Parsing a
+// field under its own reserved name — rather than its role ("title", "message",
+// "params[k]") — means a snippet named like a field can never clobber it, and a
+// snippet can't shadow the root holder (which would nil its parse tree on clone
+// and panic at render). Both are rejected as snippet names.
+const (
+	rootName  = "_chaski_root"
+	fieldName = "_chaski_field"
+)
+
 // NewSet parses the named snippets into a shared template tree.
 func NewSet(snippets map[string]string) (*Set, error) {
-	base := template.New("chaski").
+	base := template.New(rootName).
 		Option("missingkey=default").
 		Funcs(tmpl.FuncMap()).
 		// include must already exist when a snippet that uses it is parsed; the
@@ -71,6 +82,9 @@ func NewSet(snippets map[string]string) (*Set, error) {
 	// Sorted only for a deterministic error on the first bad snippet; a forward
 	// {{ template }} reference resolves at execute time, so order is irrelevant.
 	for _, name := range slices.Sorted(maps.Keys(snippets)) {
+		if name == rootName || name == fieldName {
+			return nil, fmt.Errorf("render: template name %q is reserved", name)
+		}
 		if _, err := base.New(name).Parse(snippets[name]); err != nil {
 			return nil, fmt.Errorf("render: parse template %q: %w", name, err)
 		}
@@ -90,7 +104,10 @@ func (s *Set) Compile(name, text string) (*Template, error) {
 		return nil, fmt.Errorf("render: clone for %s: %w", name, err)
 	}
 	root.Funcs(template.FuncMap{"include": includeFunc(root)})
-	t, err := root.New(name).Parse(text)
+	// Parse under the reserved fieldName, never the role name, so a snippet named
+	// like this field is not overwritten; the field still reaches snippets by
+	// their own names. The human name stays in the error for attribution.
+	t, err := root.New(fieldName).Parse(text)
 	if err != nil {
 		return nil, fmt.Errorf("render: parse %s: %w", name, err)
 	}

--- a/internal/render/set_test.go
+++ b/internal/render/set_test.go
@@ -2,6 +2,7 @@ package render_test
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/home-operations/chaski/internal/render"
@@ -69,6 +70,77 @@ func TestSetBadSnippetFailsAtLoad(t *testing.T) {
 	if _, err := render.NewSet(map[string]string{"bad": "{{ .x. }}"}); err == nil {
 		t.Fatal("NewSet with a malformed snippet = nil error, want a parse error")
 	}
+}
+
+// TestSetFieldNameDoesNotCollideWithSnippet pins the fix for a snippet named
+// like a field role: it must not be clobbered by the field of the same name,
+// and {{ template "title" . }} must resolve to the snippet (not self-recurse).
+func TestSetFieldNameDoesNotCollideWithSnippet(t *testing.T) {
+	s := mustSet(t, map[string]string{"title": "[{{ .payload.sev }}]"})
+	tpl, err := s.Compile("title", `{{ template "title" . }} alert`)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := tpl.Render(render.Data{Payload: map[string]any{"sev": "CRIT"}})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if got != "[CRIT] alert" {
+		t.Errorf("got %q, want %q", got, "[CRIT] alert")
+	}
+
+	// The required "message" field is the case that 500s on a collision.
+	sm := mustSet(t, map[string]string{"message": "body:{{ .payload.x }}"})
+	mt, err := sm.Compile("message", `{{ template "message" . }}`)
+	if err != nil {
+		t.Fatalf("Compile message: %v", err)
+	}
+	if got, err := mt.Render(render.Data{Payload: map[string]any{"x": "1"}}); err != nil || got != "body:1" {
+		t.Errorf("message render = %q, %v; want body:1", got, err)
+	}
+}
+
+func TestSetReservedNamesRejected(t *testing.T) {
+	for _, name := range []string{"_chaski_root", "_chaski_field"} {
+		if _, err := render.NewSet(map[string]string{name: "x"}); err == nil {
+			t.Errorf("NewSet with reserved name %q = nil error, want rejection", name)
+		}
+	}
+	// The app name itself is not reserved — operators may use it as a snippet.
+	if _, err := render.NewSet(map[string]string{"chaski": "x"}); err != nil {
+		t.Errorf(`NewSet with snippet "chaski" = %v, want ok`, err)
+	}
+}
+
+func TestSetIncludeUnknownErrorsAtRender(t *testing.T) {
+	s := mustSet(t, nil)
+	tpl, err := s.Compile("title", `{{ include "nope" . }}`)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if _, err := tpl.Render(render.Data{}); err == nil {
+		t.Error("include of an undefined template = nil error, want a render error")
+	}
+}
+
+// TestSetConcurrentRender locks in the parse-once / execute-concurrently
+// contract: one compiled template (with a snippet + include path) rendered from
+// many goroutines must be race-free under `go test -race`.
+func TestSetConcurrentRender(t *testing.T) {
+	s := mustSet(t, map[string]string{"label": "[{{ .payload.lvl }}]"})
+	tpl, err := s.Compile("title", `{{ template "label" . }} {{ include "label" . }}`)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			if got, err := tpl.Render(render.Data{Payload: map[string]any{"lvl": "I"}}); err != nil || got != "[I] [I]" {
+				t.Errorf("concurrent render = %q, %v", got, err)
+			}
+		})
+	}
+	wg.Wait()
 }
 
 func TestSetUnknownTemplateErrorsAtRender(t *testing.T) {


### PR DESCRIPTION
A review of the named-templates feature (#12, already merged) found a namespace collision in how route fields are compiled against the shared snippet tree. This fixes it.

## The bug

Each route field was parsed into the snippet tree **under its own role name** — `title`, `message`, `params[key]`. So a snippet named like a field role collided with it:

- A snippet named `title` (or `message`, or a `params`/`headers` key) was **overwritten** by the field of the same name. `{{ template "title" . }}` then resolved to the field itself and **self-recursed** — a render fault returned as HTTP 500 for a required field, or silently lost output for an optional one.
- A snippet named `chaski` (the holder template's base name) **niled the holder's parse tree on clone** and **panicked** at render.

Neither is exotic — `title`/`message` are the most natural snippet names an operator would pick for a shared title or body.

## The fix

Parse every field under a reserved internal name (`_chaski_field`) and name the holder explicitly (`_chaski_root`), so a field can never collide with a snippet or the root. Both reserved names are rejected as snippet names. A field still reaches every snippet by its own name.

Adds tests for the collision (snippet named `title`/`message`), reserved-name rejection, unknown `include`, and concurrent render under `-race`.

## Also

- **README**: corrected the claim that an undefined `{{ template "typo" . }}` "fails at boot / `chaski validate`" — it parses cleanly and faults only at render, so the text now points at `validate --payload`. Added a note that a snippet must not reference itself (like Helm's `include`, it recurses without limit).
- **`chaski validate`**: the summary now lists `templates:` with their source fragment, alongside routes and targets.

`go test -race ./...`, `golangci-lint` (0), `gofmt`, `generate-check`, `helm lint`/`unittest` all green.
