### PR TITLE
fix(render): validate the snippet reference graph at load

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,12 +237,13 @@ routes:
     title: '{{ include "label" . }} audit: {{ .payload.action }}'
 ```
 
-Both routes render `[CRITICAL] …` from the one `label` snippet. A malformed
-snippet fails at boot / `chaski validate`, but an undefined `{{ template "typo"
-. }}` reference parses cleanly and only faults at render (the route returns 500) — run `chaski validate --payload sample.json` to exercise the templates
-before deploy. A snippet must not reference itself (directly or through a
-cycle); like Helm's `include`, a self-reference recurses without limit. `whenExpr`
-is CEL, so snippets don't apply there — only to the Go-template fields.
+Both routes render `[CRITICAL] …` from the one `label` snippet. Snippet wiring
+is checked at boot / `chaski validate`, so the whole class of typos fails fast
+rather than at request time: a malformed snippet, a reference to an undefined
+snippet, and a reference cycle (`a` → `b` → `a`) are all rejected before the
+server serves. An `include` name must be a string literal (`{{ include "label"
+. }}`), like the `{{ template }}` action. `whenExpr` is CEL, so snippets don't
+apply there — only to the Go-template fields.
 
 ## SMTP ingestion
 

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -118,6 +118,31 @@ routes: { r: { target: po, message: 'x' } }
 	}
 }
 
+// TestCyclicTemplateFailsBuild pins the headline fix: an include cycle (which at
+// render would recurse until the goroutine stack overflows — an unrecoverable
+// crash) is rejected at Build, i.e. boot / `chaski validate`, not at request time.
+func TestCyclicTemplateFailsBuild(t *testing.T) {
+	const y = `
+templates:
+  loop: '{{ include "loop" . }}'
+targets: { po: { apprise: { url: 'pover://u@t/' } } }
+routes: { r: { target: po, message: '{{ template "loop" . }}' } }
+`
+	dir := t.TempDir()
+	file := filepath.Join(dir, "c.yaml")
+	if err := os.WriteFile(file, []byte(y), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rc, err := config.LoadRouteConfig(file)
+	if err != nil {
+		t.Fatalf("LoadRouteConfig: %v", err)
+	}
+	cfg := &config.Config{RetryAttempts: 1, RetryBackoff: time.Millisecond, RequestTimeout: time.Second}
+	if _, err := relay.Build(rc, cfg, relay.Options{Notifier: &fakeNotifier{}}); err == nil {
+		t.Fatal("relay.Build with a template cycle = nil error, want a cycle error")
+	}
+}
+
 func TestGateSkips(t *testing.T) {
 	fn := &fakeNotifier{}
 	r := route(t, engine(t, apprise1, fn))

--- a/internal/render/refs.go
+++ b/internal/render/refs.go
@@ -1,0 +1,169 @@
+package render
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"text/template"
+	"text/template/parse"
+)
+
+// references walks a parsed template tree and returns every template name it
+// references, both via the {{ template "x" }} action and via the include "x"
+// function call. An include whose name argument is not a string literal is an
+// error: a non-literal name (a field path, a variable, a pipeline) cannot be
+// resolved at load, so it can be neither checked for existence nor for a cycle —
+// and could be payload-derived. We require it to be constant, which also matches
+// the {{ template }} action, whose name is always a literal. The returned names
+// may contain duplicates; callers that care dedupe.
+func references(tree *parse.Tree) ([]string, error) {
+	if tree == nil || tree.Root == nil {
+		return nil, nil
+	}
+
+	var (
+		refs   []string
+		badErr error
+	)
+
+	var walkNode func(parse.Node)
+	var walkPipe func(*parse.PipeNode)
+
+	walkPipe = func(p *parse.PipeNode) {
+		if p == nil {
+			return
+		}
+		for _, cmd := range p.Cmds {
+			if len(cmd.Args) > 0 {
+				if id, ok := cmd.Args[0].(*parse.IdentifierNode); ok && id.Ident == includeName {
+					switch {
+					case len(cmd.Args) < 2:
+						if badErr == nil {
+							badErr = fmt.Errorf(`include needs a template name, e.g. {{ include "name" . }}`)
+						}
+					default:
+						if s, ok := cmd.Args[1].(*parse.StringNode); ok {
+							refs = append(refs, s.Text)
+						} else if badErr == nil {
+							badErr = fmt.Errorf(`include template name must be a string literal, e.g. {{ include "name" . }}`)
+						}
+					}
+				}
+			}
+			// An argument may itself be a parenthesized pipeline, e.g.
+			// {{ printf "%s" (include "x" .) }}.
+			for _, arg := range cmd.Args {
+				if pn, ok := arg.(*parse.PipeNode); ok {
+					walkPipe(pn)
+				}
+			}
+		}
+	}
+
+	walkNode = func(n parse.Node) {
+		switch x := n.(type) {
+		case *parse.ListNode:
+			if x == nil {
+				return
+			}
+			for _, c := range x.Nodes {
+				walkNode(c)
+			}
+		case *parse.ActionNode:
+			walkPipe(x.Pipe)
+		case *parse.IfNode:
+			walkPipe(x.Pipe)
+			walkNode(x.List)
+			walkNode(x.ElseList)
+		case *parse.RangeNode:
+			walkPipe(x.Pipe)
+			walkNode(x.List)
+			walkNode(x.ElseList)
+		case *parse.WithNode:
+			walkPipe(x.Pipe)
+			walkNode(x.List)
+			walkNode(x.ElseList)
+		case *parse.TemplateNode:
+			refs = append(refs, x.Name)
+			walkPipe(x.Pipe)
+		}
+	}
+
+	walkNode(tree.Root)
+	if badErr != nil {
+		return nil, badErr
+	}
+	return refs, nil
+}
+
+// checkRefs verifies every name an owner references resolves to a declared
+// snippet and is not a reserved name. owner is used only for attribution.
+func checkRefs(owner string, refs []string, defined map[string]bool) error {
+	for _, r := range refs {
+		switch {
+		case r == rootName || r == fieldName:
+			return fmt.Errorf("render: template %q references the reserved name %q", owner, r)
+		case !defined[r]:
+			return fmt.Errorf("render: template %q references undefined snippet %q", owner, r)
+		}
+	}
+	return nil
+}
+
+// checkAcyclic reports the first cycle in the snippet reference graph, naming the
+// path. An include cycle is the dangerous case: include re-enters via
+// ExecuteTemplate, which resets text/template's depth guard, so a cycle recurses
+// until the goroutine stack overflows — a runtime-fatal crash that recover()
+// cannot catch. Rejecting it here turns that into a load-time error.
+func checkAcyclic(refs map[string][]string) error {
+	const (
+		white = iota
+		gray
+		black
+	)
+	color := make(map[string]int, len(refs))
+	var path []string
+
+	var visit func(string) error
+	visit = func(n string) error {
+		color[n] = gray
+		path = append(path, n)
+		for _, m := range refs[n] {
+			switch color[m] {
+			case gray:
+				cycle := append(slices.Clone(path[slices.Index(path, m):]), m)
+				return fmt.Errorf("render: template cycle: %s", strings.Join(cycle, " → "))
+			case white:
+				if err := visit(m); err != nil {
+					return err
+				}
+			}
+		}
+		path = path[:len(path)-1]
+		color[n] = black
+		return nil
+	}
+
+	for _, n := range slices.Sorted(maps.Keys(refs)) {
+		if color[n] == white {
+			if err := visit(n); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// extraTemplate returns the name of any template associated with t that is not in
+// allowed, or "" if there is none. It catches {{ define }}/{{ block }} inside a
+// snippet or field body, which would add templates the reference analysis does
+// not model (and could shadow a snippet or the reserved names).
+func extraTemplate(t *template.Template, allowed map[string]bool) string {
+	for _, a := range t.Templates() {
+		if n := a.Name(); n != "" && !allowed[n] {
+			return n
+		}
+	}
+	return ""
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -56,7 +56,8 @@ type Template struct {
 // template can reuse a snippet via {{ template "name" . }} or {{ include
 // "name" . }}; snippets may reference one another. Build it once at load.
 type Set struct {
-	base *template.Template // holds the snippets; cloned per compiled field
+	base    *template.Template // holds the snippets; cloned per compiled field
+	defined map[string]bool    // snippet names, for validating field references
 }
 
 // Reserved template names. rootName is the base/holder template (never
@@ -68,9 +69,19 @@ type Set struct {
 const (
 	rootName  = "_chaski_root"
 	fieldName = "_chaski_field"
+	// includeName is the funcmap key for the include helper; also matched by name
+	// when scanning parse trees for include references.
+	includeName = "include"
 )
 
-// NewSet parses the named snippets into a shared template tree.
+// NewSet parses the named snippets into a shared template tree and validates
+// their reference graph: every {{ template }} / include reference must resolve to
+// a declared snippet, no snippet may reference a reserved name, and the graph must
+// be acyclic. The graph checks matter because include re-enters via
+// ExecuteTemplate (resetting text/template's depth guard), so a cycle would
+// recurse until the goroutine stack overflows — a runtime-fatal crash recover()
+// cannot catch. Validating here makes that, and a dangling reference, a load-time
+// failure (boot / `chaski validate`) instead of a render-time fault.
 func NewSet(snippets map[string]string) (*Set, error) {
 	base := template.New(rootName).
 		Option("missingkey=default").
@@ -78,18 +89,47 @@ func NewSet(snippets map[string]string) (*Set, error) {
 		// include must already exist when a snippet that uses it is parsed; the
 		// real implementation is bound per field in Compile (it needs the field's
 		// own tree to resolve names).
-		Funcs(template.FuncMap{"include": includePlaceholder})
-	// Sorted only for a deterministic error on the first bad snippet; a forward
-	// {{ template }} reference resolves at execute time, so order is irrelevant.
-	for _, name := range slices.Sorted(maps.Keys(snippets)) {
-		if name == rootName || name == fieldName {
+		Funcs(template.FuncMap{includeName: includePlaceholder})
+
+	names := slices.Sorted(maps.Keys(snippets)) // deterministic errors
+	defined := make(map[string]bool, len(names))
+	refs := make(map[string][]string, len(names))
+	allowed := map[string]bool{rootName: true}
+	for _, name := range names {
+		switch name {
+		case "":
+			return nil, fmt.Errorf("render: a template name must not be empty")
+		case rootName, fieldName:
 			return nil, fmt.Errorf("render: template name %q is reserved", name)
 		}
-		if _, err := base.New(name).Parse(snippets[name]); err != nil {
+		t, err := base.New(name).Parse(snippets[name])
+		if err != nil {
 			return nil, fmt.Errorf("render: parse template %q: %w", name, err)
 		}
+		r, err := references(t.Tree)
+		if err != nil {
+			return nil, fmt.Errorf("render: template %q: %w", name, err)
+		}
+		defined[name] = true
+		refs[name] = r
+		allowed[name] = true
 	}
-	return &Set{base: base}, nil
+
+	// A {{ define }}/{{ block }} in a snippet body would add a template the graph
+	// analysis below doesn't see (and could shadow a snippet or a reserved name).
+	if extra := extraTemplate(base, allowed); extra != "" {
+		return nil, fmt.Errorf("render: snippet defines a nested template %q; {{ define }}/{{ block }} are not supported", extra)
+	}
+	for _, name := range names {
+		if err := checkRefs(name, refs[name], defined); err != nil {
+			return nil, err
+		}
+	}
+	if err := checkAcyclic(refs); err != nil {
+		return nil, err
+	}
+
+	return &Set{base: base, defined: defined}, nil
 }
 
 // Compile parses one field template into a clone of the snippet tree, so the
@@ -103,13 +143,29 @@ func (s *Set) Compile(name, text string) (*Template, error) {
 	if err != nil {
 		return nil, fmt.Errorf("render: clone for %s: %w", name, err)
 	}
-	root.Funcs(template.FuncMap{"include": includeFunc(root)})
+	root.Funcs(template.FuncMap{includeName: includeFunc(root)})
 	// Parse under the reserved fieldName, never the role name, so a snippet named
 	// like this field is not overwritten; the field still reaches snippets by
 	// their own names. The human name stays in the error for attribution.
 	t, err := root.New(fieldName).Parse(text)
 	if err != nil {
 		return nil, fmt.Errorf("render: parse %s: %w", name, err)
+	}
+	// Validate the field's references like a snippet's: they must resolve to a
+	// declared snippet and not a reserved name. The snippet graph is already
+	// acyclic and cannot reference the field (its reserved name is rejected), so
+	// the field is a pure source node and cannot introduce a cycle.
+	r, err := references(t.Tree)
+	if err != nil {
+		return nil, fmt.Errorf("render: %s: %w", name, err)
+	}
+	allowed := map[string]bool{rootName: true, fieldName: true}
+	maps.Copy(allowed, s.defined)
+	if extra := extraTemplate(root, allowed); extra != "" {
+		return nil, fmt.Errorf("render: %s defines a nested template %q; {{ define }}/{{ block }} are not supported", name, extra)
+	}
+	if err := checkRefs(name, r, s.defined); err != nil {
+		return nil, err
 	}
 	return &Template{t: t, src: text}, nil
 }

--- a/internal/render/set_test.go
+++ b/internal/render/set_test.go
@@ -112,14 +112,10 @@ func TestSetReservedNamesRejected(t *testing.T) {
 	}
 }
 
-func TestSetIncludeUnknownErrorsAtRender(t *testing.T) {
+func TestSetIncludeUnknownErrorsAtLoad(t *testing.T) {
 	s := mustSet(t, nil)
-	tpl, err := s.Compile("title", `{{ include "nope" . }}`)
-	if err != nil {
-		t.Fatalf("Compile: %v", err)
-	}
-	if _, err := tpl.Render(render.Data{}); err == nil {
-		t.Error("include of an undefined template = nil error, want a render error")
+	if _, err := s.Compile("title", `{{ include "nope" . }}`); err == nil {
+		t.Error("include of an undefined snippet = nil error, want a load error")
 	}
 }
 
@@ -143,16 +139,90 @@ func TestSetConcurrentRender(t *testing.T) {
 	wg.Wait()
 }
 
-func TestSetUnknownTemplateErrorsAtRender(t *testing.T) {
-	// A reference to an undefined template parses (resolved at execute) but is a
-	// render error, surfaced as a route fault rather than silently empty.
+func TestSetUnknownTemplateErrorsAtLoad(t *testing.T) {
+	// A reference to an undefined template parses (resolved at execute), but the
+	// reference graph is validated at compile, so a dangling name fails fast at
+	// load rather than as a render-time HTTP 500.
 	s := mustSet(t, nil)
-	tpl, err := s.Compile("title", `{{ template "missing" . }}`)
+	if _, err := s.Compile("title", `{{ template "missing" . }}`); err == nil {
+		t.Error("Compile with an undefined template = nil error, want a load error")
+	}
+}
+
+// TestSetIncludeFromInsideSnippet exercises the path the clone+rebind fix relies
+// on: include called from WITHIN a snippet (not just from the field) must resolve
+// to the real include func, not the parse-time placeholder.
+func TestSetIncludeFromInsideSnippet(t *testing.T) {
+	s := mustSet(t, map[string]string{
+		"outer": `<{{ include "inner" . }}>`,
+		"inner": `{{ .payload.x }}`,
+	})
+	tpl, err := s.Compile("title", `{{ template "outer" . }}`)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	if _, err := tpl.Render(render.Data{}); err == nil {
-		t.Error("Render with an undefined template = nil error, want a render error")
+	got, err := tpl.Render(render.Data{Payload: map[string]any{"x": "VAL"}})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if got != "<VAL>" {
+		t.Errorf("got %q, want %q", got, "<VAL>")
+	}
+}
+
+func TestSetIncludeCycleRejected(t *testing.T) {
+	// A self-referential include cycle is the dangerous case: at render it would
+	// recurse until the goroutine stack overflows (an unrecoverable crash). It
+	// must be rejected at load instead.
+	if _, err := render.NewSet(map[string]string{"loop": `{{ include "loop" . }}`}); err == nil {
+		t.Error("NewSet with a self-referential include = nil error, want a cycle error")
+	}
+	// Mutual cycle across two snippets.
+	if _, err := render.NewSet(map[string]string{
+		"a": `x {{ include "b" . }}`,
+		"b": `y {{ include "a" . }}`,
+	}); err == nil {
+		t.Error("NewSet with a mutual include cycle = nil error, want a cycle error")
+	}
+}
+
+func TestSetTemplateActionCycleRejected(t *testing.T) {
+	if _, err := render.NewSet(map[string]string{"loop": `{{ template "loop" . }}`}); err == nil {
+		t.Error("NewSet with a self-referential template action = nil error, want a cycle error")
+	}
+}
+
+func TestSetReservedReferenceRejected(t *testing.T) {
+	// The reserved field name is rejected as a snippet key (TestSetReservedNames-
+	// Rejected); it must also be rejected as a reference target, so it can't be
+	// reached as a call target to set up a field<->snippet loop.
+	if _, err := render.NewSet(map[string]string{"s": `{{ template "_chaski_field" . }}`}); err == nil {
+		t.Error("snippet referencing the reserved field name = nil error, want rejection")
+	}
+	s := mustSet(t, nil)
+	if _, err := s.Compile("message", `{{ template "_chaski_field" . }}`); err == nil {
+		t.Error("field referencing the reserved field name = nil error, want rejection")
+	}
+}
+
+func TestSetNonLiteralIncludeRejected(t *testing.T) {
+	// A non-literal include name can't be checked for existence or cycles at load
+	// (and could be payload-derived), so it is rejected.
+	s := mustSet(t, map[string]string{"greet": "hi"})
+	if _, err := s.Compile("title", `{{ include .payload.which . }}`); err == nil {
+		t.Error("include with a non-literal name = nil error, want rejection")
+	}
+}
+
+func TestSetEmptyNameRejected(t *testing.T) {
+	if _, err := render.NewSet(map[string]string{"": "x"}); err == nil {
+		t.Error(`NewSet with an empty template name = nil error, want rejection`)
+	}
+}
+
+func TestSetNestedDefineRejected(t *testing.T) {
+	if _, err := render.NewSet(map[string]string{"s": `{{ define "extra" }}x{{ end }}`}); err == nil {
+		t.Error("snippet using {{ define }} = nil error, want rejection")
 	}
 }
 


### PR DESCRIPTION
Follow-up to #13. A post-merge review of the named-templates feature found that #13's collision fix left a worse failure mode in place — and this fixes it at the root.

## The bug

`include` is a funcmap helper implemented as `t.ExecuteTemplate(...)`. Each call starts a **fresh** text/template execution state, so the stdlib `maxExecDepth` guard (which only counts depth within one `Execute`, for the `{{ template }}` action) **never trips on `include`**. A self- or mutually-recursive `include`:

```yaml
templates:
  loop: '{{ include "loop" . }}'
routes:
  r: { target: po, message: '{{ template "loop" . }}' }
```

recursed until the goroutine stack overflowed — `fatal error: stack overflow`. That's a Go **runtime-fatal, which `recover()` cannot catch**, so the recoverer middleware was powerless and the whole pod died on the first matching webhook, then CrashLooped. It passed boot *and* `chaski validate`. Strictly worse than the pre-#13 HTTP 500. Reachable from a plausible config typo.

## The fix — fail fast at load

Validate the snippet **reference graph** when the set is built (boot / `chaski validate`), so the whole class of misconfig fails before the server serves:

- Parse every snippet and field, collect their `{{ template }}` and `include` references (a recursive `text/template/parse` tree walk).
- Reject a reference to an **undefined snippet**, a reference to a **reserved name**, and any **cycle** (`a → b → a`), naming the cycle path.
- `include`'s name must be a **string literal** (matching the `{{ template }}` action) so it's resolvable at load — a non-literal name can't be cycle-checked and could be payload-derived.
- A `{{ define }}`/`{{ block }}` inside a snippet/field body is rejected (it would add a template the graph analysis doesn't model).

A cyclic config is now `chaski validate: relay: render: template cycle: loop → loop` (exit 1), not a crash. This also closes the residual door from #13: the reserved field name was blocked as a snippet *key* but still reachable as a `{{ template }}` *target*.

## Verified

- New tests: include/template cycles (self + mutual), dangling refs, reserved-name refs, non-literal include, empty names, nested `define`, and `include` from inside a snippet. The undefined-reference tests now assert a **load-time** error.
- End-to-end: `chaski validate` on a cyclic config exits 1 with a clean cycle error (no crash); a dangling-ref typo is caught at load; a valid config still validates.
- `go test -race ./...`, `golangci-lint` (0), `gofmt`, `go vet`, `generate-check`, `helm lint`/`unittest` all green.
