### PR TITLE
fix(render): make the snippet reference walk fail-closed

### DIFF
--- a/internal/render/refs.go
+++ b/internal/render/refs.go
@@ -5,96 +5,139 @@ import (
 	"maps"
 	"slices"
 	"strings"
-	"text/template"
 	"text/template/parse"
 )
 
 // references walks a parsed template tree and returns every template name it
 // references, both via the {{ template "x" }} action and via the include "x"
-// function call. An include whose name argument is not a string literal is an
-// error: a non-literal name (a field path, a variable, a pipeline) cannot be
-// resolved at load, so it can be neither checked for existence nor for a cycle —
-// and could be payload-derived. We require it to be constant, which also matches
-// the {{ template }} action, whose name is always a literal. The returned names
-// may contain duplicates; callers that care dedupe.
+// function call. It is the soundness-critical half of the load-time cycle check:
+// if a reference could hide in a node the walk skips, a cycle would slip through
+// to a render-time stack overflow. So the walk is fail-closed — it descends into
+// every node that can carry a pipeline (including a parenthesized pipeline behind
+// a field access, a *parse.ChainNode) and returns an error on any node type it
+// does not recognize, rather than treating an unknown node as reference-free.
+//
+// An include whose name argument is not a string literal is an error: a
+// non-literal name (a field path, a variable, a pipeline, or one supplied by
+// pipe) cannot be resolved at load, so it can be neither checked for existence
+// nor for a cycle — and could be payload-derived. Requiring a literal matches the
+// {{ template }} action, whose name is always literal. Returned names may contain
+// duplicates; callers that care dedupe.
 func references(tree *parse.Tree) ([]string, error) {
 	if tree == nil || tree.Root == nil {
 		return nil, nil
 	}
+	w := &refWalker{}
+	w.node(tree.Root)
+	if w.err != nil {
+		return nil, w.err
+	}
+	return w.refs, nil
+}
 
-	var (
-		refs   []string
-		badErr error
-	)
+// refWalker accumulates references and the first walk error as it descends a
+// parse tree.
+type refWalker struct {
+	refs []string
+	err  error
+}
 
-	var walkNode func(parse.Node)
-	var walkPipe func(*parse.PipeNode)
+func (w *refWalker) badInclude() {
+	if w.err == nil {
+		w.err = fmt.Errorf(`include must be called directly with a string-literal name, e.g. {{ include "name" . }}`)
+	}
+}
 
-	walkPipe = func(p *parse.PipeNode) {
-		if p == nil {
+func (w *refWalker) node(n parse.Node) {
+	if n == nil || w.err != nil {
+		return
+	}
+	switch x := n.(type) {
+	case *parse.ListNode:
+		if x == nil {
 			return
 		}
-		for _, cmd := range p.Cmds {
-			if len(cmd.Args) > 0 {
-				if id, ok := cmd.Args[0].(*parse.IdentifierNode); ok && id.Ident == includeName {
-					switch {
-					case len(cmd.Args) < 2:
-						if badErr == nil {
-							badErr = fmt.Errorf(`include needs a template name, e.g. {{ include "name" . }}`)
-						}
-					default:
-						if s, ok := cmd.Args[1].(*parse.StringNode); ok {
-							refs = append(refs, s.Text)
-						} else if badErr == nil {
-							badErr = fmt.Errorf(`include template name must be a string literal, e.g. {{ include "name" . }}`)
-						}
-					}
-				}
-			}
-			// An argument may itself be a parenthesized pipeline, e.g.
-			// {{ printf "%s" (include "x" .) }}.
-			for _, arg := range cmd.Args {
-				if pn, ok := arg.(*parse.PipeNode); ok {
-					walkPipe(pn)
-				}
-			}
+		for _, c := range x.Nodes {
+			w.node(c)
+		}
+	case *parse.ActionNode:
+		w.pipe(x.Pipe)
+	case *parse.IfNode:
+		w.branch(x.Pipe, x.List, x.ElseList)
+	case *parse.RangeNode:
+		w.branch(x.Pipe, x.List, x.ElseList)
+	case *parse.WithNode:
+		w.branch(x.Pipe, x.List, x.ElseList)
+	case *parse.TemplateNode:
+		w.refs = append(w.refs, x.Name)
+		w.pipe(x.Pipe)
+	case *parse.PipeNode:
+		w.pipe(x)
+	case *parse.ChainNode:
+		w.node(x.Node)
+	case *parse.TextNode, *parse.BoolNode, *parse.DotNode, *parse.FieldNode,
+		*parse.IdentifierNode, *parse.NilNode, *parse.NumberNode,
+		*parse.StringNode, *parse.VariableNode, *parse.CommentNode,
+		*parse.BreakNode, *parse.ContinueNode:
+		// Leaf nodes — they cannot hold a template/include reference.
+	default:
+		// Fail closed: an unmodeled node could hide a reference, and treating it
+		// as reference-free is how a cycle would reach a render crash.
+		if w.err == nil {
+			w.err = fmt.Errorf("unsupported template node %T", n)
 		}
 	}
+}
 
-	walkNode = func(n parse.Node) {
-		switch x := n.(type) {
-		case *parse.ListNode:
-			if x == nil {
-				return
+// branch walks the pipe, body, and else of an if/range/with.
+func (w *refWalker) branch(pipe *parse.PipeNode, list, elseList *parse.ListNode) {
+	w.pipe(pipe)
+	w.node(list)
+	w.node(elseList)
+}
+
+func (w *refWalker) pipe(p *parse.PipeNode) {
+	if p == nil || w.err != nil {
+		return
+	}
+	for _, cmd := range p.Cmds {
+		w.command(cmd)
+	}
+}
+
+func (w *refWalker) command(cmd *parse.CommandNode) {
+	args := cmd.Args
+	// include must appear ONLY as a command head with a string-literal name.
+	// Anywhere else — not the head (so passed to call, printf, …) or the head
+	// without a literal name (bound to a variable, name supplied by pipe or
+	// parens) — means include is invoked indirectly, with a name that can't be
+	// resolved at load, so a cycle through it could slip past the graph check to
+	// a render-time stack overflow. Scan every position.
+	for i, arg := range args {
+		id, ok := arg.(*parse.IdentifierNode)
+		if !ok || id.Ident != includeName {
+			continue
+		}
+		if i == 0 && len(args) >= 2 {
+			if sn, ok := args[1].(*parse.StringNode); ok {
+				w.refs = append(w.refs, sn.Text)
+				continue
 			}
-			for _, c := range x.Nodes {
-				walkNode(c)
-			}
-		case *parse.ActionNode:
-			walkPipe(x.Pipe)
-		case *parse.IfNode:
-			walkPipe(x.Pipe)
-			walkNode(x.List)
-			walkNode(x.ElseList)
-		case *parse.RangeNode:
-			walkPipe(x.Pipe)
-			walkNode(x.List)
-			walkNode(x.ElseList)
-		case *parse.WithNode:
-			walkPipe(x.Pipe)
-			walkNode(x.List)
-			walkNode(x.ElseList)
-		case *parse.TemplateNode:
-			refs = append(refs, x.Name)
-			walkPipe(x.Pipe)
+		}
+		w.badInclude()
+	}
+	// An argument may itself carry a pipeline: a bare parenthesized pipeline
+	// (*parse.PipeNode) or one followed by a field/method access (*parse.ChainNode,
+	// e.g. (include "x" .).Field). Both must be walked or a reference inside them
+	// is missed.
+	for _, arg := range args {
+		switch a := arg.(type) {
+		case *parse.PipeNode:
+			w.pipe(a)
+		case *parse.ChainNode:
+			w.node(a)
 		}
 	}
-
-	walkNode(tree.Root)
-	if badErr != nil {
-		return nil, badErr
-	}
-	return refs, nil
 }
 
 // checkRefs verifies every name an owner references resolves to a declared
@@ -153,17 +196,4 @@ func checkAcyclic(refs map[string][]string) error {
 		}
 	}
 	return nil
-}
-
-// extraTemplate returns the name of any template associated with t that is not in
-// allowed, or "" if there is none. It catches {{ define }}/{{ block }} inside a
-// snippet or field body, which would add templates the reference analysis does
-// not model (and could shadow a snippet or the reserved names).
-func extraTemplate(t *template.Template, allowed map[string]bool) string {
-	for _, a := range t.Templates() {
-		if n := a.Name(); n != "" && !allowed[n] {
-			return n
-		}
-	}
-	return ""
 }

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -94,13 +94,17 @@ func NewSet(snippets map[string]string) (*Set, error) {
 	names := slices.Sorted(maps.Keys(snippets)) // deterministic errors
 	defined := make(map[string]bool, len(names))
 	refs := make(map[string][]string, len(names))
-	allowed := map[string]bool{rootName: true}
 	for _, name := range names {
 		switch name {
 		case "":
 			return nil, fmt.Errorf("render: a template name must not be empty")
 		case rootName, fieldName:
 			return nil, fmt.Errorf("render: template name %q is reserved", name)
+		}
+		// Reject {{ define }}/{{ block }} before parsing into base, so a nested
+		// define can't mutate the shared tree the cycle check relies on.
+		if err := rejectNestedTemplates(fmt.Sprintf("template %q", name), snippets[name]); err != nil {
+			return nil, err
 		}
 		t, err := base.New(name).Parse(snippets[name])
 		if err != nil {
@@ -112,14 +116,8 @@ func NewSet(snippets map[string]string) (*Set, error) {
 		}
 		defined[name] = true
 		refs[name] = r
-		allowed[name] = true
 	}
 
-	// A {{ define }}/{{ block }} in a snippet body would add a template the graph
-	// analysis below doesn't see (and could shadow a snippet or a reserved name).
-	if extra := extraTemplate(base, allowed); extra != "" {
-		return nil, fmt.Errorf("render: snippet defines a nested template %q; {{ define }}/{{ block }} are not supported", extra)
-	}
 	for _, name := range names {
 		if err := checkRefs(name, refs[name], defined); err != nil {
 			return nil, err
@@ -132,11 +130,37 @@ func NewSet(snippets map[string]string) (*Set, error) {
 	return &Set{base: base, defined: defined}, nil
 }
 
+// rejectNestedTemplates errors if body uses {{ define }} or {{ block }}. Those
+// add a template to the shared tree that the reference analysis can't model and
+// that could shadow a snippet, the field, or the reserved holder — re-opening a
+// cycle the graph check already ruled out. It parses body in isolation: a body
+// with no nested template yields exactly one, so it catches a redefinition of an
+// existing name as readily as a new one, regardless of parse order. (Defining
+// the probe's own name is itself a parse error, so it can't evade the count.)
+func rejectNestedTemplates(label, body string) error {
+	probe := template.New("_probe").
+		Option("missingkey=default").
+		Funcs(tmpl.FuncMap()).
+		Funcs(template.FuncMap{includeName: includePlaceholder})
+	if _, err := probe.Parse(body); err != nil {
+		return fmt.Errorf("render: parse %s: %w", label, err)
+	}
+	if len(probe.Templates()) > 1 {
+		return fmt.Errorf("render: %s uses {{ define }}/{{ block }}, which is not supported", label)
+	}
+	return nil
+}
+
 // Compile parses one field template into a clone of the snippet tree, so the
 // field can reference any snippet. A reference to an excluded function (e.g.
 // readFile) is a parse error here, so the restriction is enforced at load, not
 // silently at render.
 func (s *Set) Compile(name, text string) (*Template, error) {
+	// Reject {{ define }}/{{ block }} first: a field that defines a snippet's name
+	// would shadow it in the clone and could reintroduce a cycle.
+	if err := rejectNestedTemplates(name, text); err != nil {
+		return nil, err
+	}
 	// Clone keeps each field's tree independent and lets include bind to it. The
 	// base is never executed, so it is always safe to clone.
 	root, err := s.base.Clone()
@@ -151,18 +175,14 @@ func (s *Set) Compile(name, text string) (*Template, error) {
 	if err != nil {
 		return nil, fmt.Errorf("render: parse %s: %w", name, err)
 	}
-	// Validate the field's references like a snippet's: they must resolve to a
+	// Validate the field's references like a snippet's: each must resolve to a
 	// declared snippet and not a reserved name. The snippet graph is already
-	// acyclic and cannot reference the field (its reserved name is rejected), so
-	// the field is a pure source node and cannot introduce a cycle.
+	// acyclic and cannot reference the field (its reserved name is rejected) or
+	// be redefined (nested defines are rejected above), so the field is a pure
+	// source node and cannot introduce a cycle.
 	r, err := references(t.Tree)
 	if err != nil {
 		return nil, fmt.Errorf("render: %s: %w", name, err)
-	}
-	allowed := map[string]bool{rootName: true, fieldName: true}
-	maps.Copy(allowed, s.defined)
-	if extra := extraTemplate(root, allowed); extra != "" {
-		return nil, fmt.Errorf("render: %s defines a nested template %q; {{ define }}/{{ block }} are not supported", name, extra)
 	}
 	if err := checkRefs(name, r, s.defined); err != nil {
 		return nil, err

--- a/internal/render/set_test.go
+++ b/internal/render/set_test.go
@@ -226,6 +226,91 @@ func TestSetNestedDefineRejected(t *testing.T) {
 	}
 }
 
+// TestSetChainNodeCycleRejected pins the walker-soundness fix: a cycle whose
+// include is hidden behind a parenthesized pipeline + field access (a
+// *parse.ChainNode, e.g. {{ (include "x" .).F }}) must still be rejected at load.
+// Before the fix the walker skipped ChainNode args, so the include edge was lost
+// and the cycle reached a render-time stack-overflow crash.
+func TestSetChainNodeCycleRejected(t *testing.T) {
+	cases := map[string]map[string]string{
+		"self":     {"loop": `{{ (include "loop" .).X }}`},
+		"mutual":   {"a": `{{ (include "b" .).X }}`, "b": `{{ (include "a" .).Y }}`},
+		"in-if":    {"loop": `{{ if (include "loop" .).Ok }}x{{ end }}`},
+		"in-range": {"loop": `{{ range (include "loop" .).Items }}x{{ end }}`},
+	}
+	for name, snippets := range cases {
+		if _, err := render.NewSet(snippets); err == nil {
+			t.Errorf("%s: NewSet accepted a cycle hidden in a ChainNode, want rejection", name)
+		}
+	}
+}
+
+// TestSetChainNodeReferenceSeen proves the ChainNode walk doesn't over-reject: a
+// non-cyclic chained include is accepted, while a chained include of an undefined
+// snippet is still caught — i.e. the reference is genuinely seen, not ignored.
+func TestSetChainNodeReferenceSeen(t *testing.T) {
+	if _, err := render.NewSet(map[string]string{"greet": "hi", "s": `{{ (include "greet" .).X }}`}); err != nil {
+		t.Errorf("NewSet rejected a valid chained include: %v", err)
+	}
+	if _, err := render.NewSet(map[string]string{"s": `{{ (include "nope" .).X }}`}); err == nil {
+		t.Error("chained include of an undefined snippet = nil error, want dangling rejection")
+	}
+}
+
+// TestSetDefineShadowRejected pins both define-shadow holes: a snippet (or a
+// field) that {{ define }}s an existing snippet's name would overwrite the
+// already-validated tree and reintroduce a cycle. The blanket nested-template
+// rejection closes both paths.
+func TestSetDefineShadowRejected(t *testing.T) {
+	if _, err := render.NewSet(map[string]string{
+		"m": "X",
+		"z": `{{ define "m" }}{{ include "z" . }}{{ end }}Z{{ include "m" . }}`,
+	}); err == nil {
+		t.Error("snippet redefining another snippet via {{ define }} = nil error, want rejection")
+	}
+	s := mustSet(t, map[string]string{"m": "X", "z": `{{ include "m" . }}`})
+	if _, err := s.Compile("message", `{{ define "m" }}{{ include "z" . }}{{ end }}{{ include "z" . }}`); err == nil {
+		t.Error("field redefining a snippet via {{ define }} = nil error, want rejection")
+	}
+}
+
+// TestSetIndirectIncludeRejected pins that include can't be invoked indirectly
+// (via the call builtin, a variable, or a pipe-supplied name), which would let a
+// cycle through include escape the static graph check and crash the process at
+// render. include is only valid as a command head with a string-literal name.
+func TestSetIndirectIncludeRejected(t *testing.T) {
+	for _, body := range []string{
+		`{{ call include "loop" . }}`,               // via the call builtin
+		`{{ printf "%v" (call include "loop" .) }}`, // call, nested in a pipe arg
+		`{{ $f := include }}{{ $f "loop" . }}`,      // bound to a variable
+		`{{ "loop" | include }}`,                    // name supplied by a pipe
+		`{{ include ("loop") . }}`,                  // name not a bare literal
+	} {
+		if _, err := render.NewSet(map[string]string{"loop": body}); err == nil {
+			t.Errorf("NewSet accepted an indirect include %q, want rejection", body)
+		}
+	}
+	// The direct, literal forms (including a trailing pipe and piped data) stay
+	// valid.
+	for _, body := range []string{
+		`{{ include "greet" . }}`,
+		`{{ include "greet" . | toUpper }}`,
+		`{{ . | include "greet" }}`,
+	} {
+		if _, err := render.NewSet(map[string]string{"greet": "hi", "s": body}); err != nil {
+			t.Errorf("NewSet rejected a valid include %q: %v", body, err)
+		}
+	}
+}
+
+func TestSetDefineReservedNameRejected(t *testing.T) {
+	// Defining the reserved holder name would slip past a name-based allow-list;
+	// the blanket define rejection covers it.
+	if _, err := render.NewSet(map[string]string{"a": `{{ define "_chaski_root" }}x{{ end }}body`}); err == nil {
+		t.Error(`snippet defining "_chaski_root" = nil error, want rejection`)
+	}
+}
+
 func TestSetCompileMapUsesSnippets(t *testing.T) {
 	s := mustSet(t, map[string]string{"pri": "high"})
 	m, err := s.CompileMap("params", map[string]string{"priority": `{{ template "pri" . }}`})


### PR DESCRIPTION
Follow-up to #14. The load-time cycle check in #14 walked template parse trees to collect `{{ template }}` and `include` references, but the walk skipped two node shapes — so a cycle could still slip past it and reach the render-time stack-overflow crash #14 was meant to eliminate. (Found by an adversarial pass over #14's own walker.)

## The two holes

**1. `ChainNode` — a parenthesized pipeline behind a field access.** `{{ (include "loop" .).X }}` parses as a `*parse.ChainNode` the walk never descended into, so the `include` edge was dropped. The self/mutual cycle was **accepted at load** and crashed the process on the first matching webhook (an `include` cycle resets text/template's depth guard, so the overflow is a Go runtime-fatal that `recover()` can't catch). Also evadable via `{{ if (include "loop" .).Ok }}` / `range`.

**2. `{{ define }}` shadow.** A snippet (or route field) that `{{ define }}`s an **existing** snippet's name overwrote the already-validated parse tree, reintroducing a cycle the graph check had cleared. #14's define check only rejected *new* names, not redefinitions.

## The fix

- **Fail-closed walk.** `references()` now descends into every node that can carry a pipeline — including `ChainNode` and a bare parenthesized `PipeNode` — and **returns an error on any node type it doesn't recognize**, so a reference can't hide from the walk (the structural cause of hole #1).
- **Shadow-proof define rejection.** `{{ define }}`/`{{ block }}` is rejected by parsing the body in isolation and counting the templates it produces, which catches a redefinition of an existing snippet (or the reserved holder) as readily as a new name, regardless of parse order. (Defining the probe's own name is itself a parse error, so it can't evade the count.)

A cycle hidden behind a `ChainNode`, and a define-shadow on either the snippet or the field path, are now load-time errors (`chaski validate: … template cycle: loop → loop`), not process crashes.

## Verified

- New tests: ChainNode-hidden cycles (self, mutual, inside `if`/`range`), proof a chained reference is still seen (valid accepted / undefined caught), and define-shadow on both the snippet and field paths.
- End-to-end: `chaski validate` on `{{ (include "loop" .).X }}` now exits 1 with a clean cycle error.
- `go test -race ./...`, `golangci-lint` (0), `gofmt`, `generate-check`, `helm lint`/`unittest` all green.
