### PR TITLE
docs: right-size the CEL surface in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,12 @@ error is retried with exponential backoff + jitter, bounded by the deadline.
 
 ## Templating
 
-`whenExpr` is [CEL](https://github.com/google/cel-go); every other field is a Go
-[`text/template`](https://pkg.go.dev/text/template) with
-[sprout](https://docs.atom.codes/sprout) helpers and `{{ env "…" }}`. Both see
-the same variables: `payload`, `headers`, `query`, `method`, `route`, `now`.
+Every rendered field — `title`, `message`, and the `params`/`headers` values —
+is a Go [`text/template`](https://pkg.go.dev/text/template) with
+[sprout](https://docs.atom.codes/sprout) helpers and `{{ env "…" }}`. The lone
+exception is the per-route gate `whenExpr`, a
+[CEL](https://github.com/google/cel-go) boolean. Both see the same variables:
+`payload`, `headers`, `query`, `method`, `route`, `now`.
 
 A richer **apprise** route — a severity-driven title, a bullet per alert, and a
 priority/sound chosen from the payload:
@@ -285,9 +287,6 @@ SMTP AUTH (PLAIN/LOGIN); with no TLS, those credentials travel in clear text. Pe
 Attachments are not forwarded.
 
 ## Configuration
-
-`whenExpr` is CEL; every other field is a Go template. Both expose the same
-variables: `payload`, `headers`, `query`, `method`, `route`, and `now`.
 
 Routes and targets are loaded from `CHASKI_CONFIG`; operational settings come
 from the environment:


### PR DESCRIPTION
`whenExpr` is a single optional per-route field, but the README led **both** `## Templating` and `## Configuration` with the same sentence — *"`whenExpr` is CEL; every other field is a Go template. Both expose the same variables…"* — duplicated nearly verbatim. That made CEL read as co-equal with the templating that's actually used in every rendered field.

- `## Templating` now leads with the templates (the everywhere case) and demotes `whenExpr` to *the lone exception — the per-route gate*.
- `## Configuration` drops the duplicated CEL/template recap (it belongs in Templating).

No behavior change; docs only. CEL still gets its intro clause and Features bullet — it just no longer headlines two sections for one boolean field.