### PR TITLE
feat(relay): per-target whenExpr for conditional fan-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ plain HTTP request.
 ## Features
 
 - **Routing by path** — `POST /notify/{route}`; each route is configured
-  independently and can fan out to several targets concurrently.
+  independently and can fan out to several targets concurrently, optionally
+  gating each target with its own `whenExpr`.
 - **CEL gate** — a per-route `whenExpr` decides whether a request is relayed.
 - **Go-template fields** — `title`, `message`, per-provider `params`, and HTTP
   `headers` are rendered per request with [sprout](https://github.com/go-sprout/sprout)
@@ -85,6 +86,25 @@ chaski validate -c ./chaski.yaml --payload sample.json --route alertmanager
 
 A route relays to one or more named targets; a target is exactly one of two
 kinds.
+
+A target entry can be a bare name or a `{ name, whenExpr }` object. The
+`whenExpr` is a CEL boolean (the same variables as the route gate) that gates
+that single target, so one route fans out only to the targets whose expression
+matches — useful for mirroring an event to the right dev instance:
+
+```yaml
+routes:
+  github:
+    whenExpr: payload.repository.full_name == "immich-app/immich" # optional route prefilter
+    target:
+      - prod-notify # bare name ⇒ always (when the route fires)
+      - { name: dev-alice, whenExpr: 'payload.sender.login == "alice"' }
+      - { name: dev-bob, whenExpr: "payload.pull_request.draft == false" }
+```
+
+The route fires on its own `whenExpr`, then each target sends only if its
+`whenExpr` (default true) also matches; if none match, the request is skipped.
+Target names and URLs are always config-defined — never taken from the payload.
 
 ### apprise
 

--- a/cmd/chaski/validate.go
+++ b/cmd/chaski/validate.go
@@ -148,7 +148,7 @@ func printSummary(w io.Writer, path string, rc *config.RouteConfig) {
 	p("ok: %s — %d route(s), %d target(s), %d template(s)\n", path, len(rc.Routes), len(rc.Targets), len(rc.Templates))
 	for _, name := range slices.Sorted(maps.Keys(rc.Routes)) {
 		r := rc.Routes[name]
-		p("  route %-24s (%s) → %v\n", name, r.Source, []string(r.Target))
+		p("  route %-24s (%s) → %v\n", name, r.Source, targetNames(r.Target))
 	}
 	for _, name := range slices.Sorted(maps.Keys(rc.Targets)) {
 		t := rc.Targets[name]
@@ -157,4 +157,17 @@ func printSummary(w io.Writer, path string, rc *config.RouteConfig) {
 	for _, name := range slices.Sorted(maps.Keys(rc.Templates)) {
 		p("  template %-21s (%s)\n", name, rc.TemplateSource(name))
 	}
+}
+
+// targetNames renders a route's fan-out list for the summary, marking a target
+// that carries its own whenExpr with a trailing "?".
+func targetNames(refs config.TargetRefs) []string {
+	names := make([]string, len(refs))
+	for i, ref := range refs {
+		names[i] = ref.Name
+		if ref.WhenExpr != "" {
+			names[i] += "?"
+		}
+	}
+	return names
 }

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -70,6 +70,26 @@ func customTypes(t reflect.Type) *jsonschema.Schema {
 				{Type: "array", Items: &jsonschema.Schema{Type: typeString}},
 			},
 		}
+	case reflect.TypeFor[config.TargetRefs]():
+		// A target is a name or a {name, whenExpr} object; the field is one such
+		// entry or a list of them.
+		props := jsonschema.NewProperties()
+		props.Set("name", &jsonschema.Schema{Type: typeString})
+		props.Set("whenExpr", &jsonschema.Schema{Type: typeString})
+		obj := &jsonschema.Schema{
+			Type:                 "object",
+			Properties:           props,
+			Required:             []string{"name"},
+			AdditionalProperties: jsonschema.FalseSchema,
+		}
+		entry := &jsonschema.Schema{OneOf: []*jsonschema.Schema{{Type: typeString}, obj}}
+		return &jsonschema.Schema{
+			OneOf: []*jsonschema.Schema{
+				{Type: typeString},
+				obj,
+				{Type: "array", Items: entry},
+			},
+		}
 	}
 	return nil
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -72,8 +72,38 @@
               "type": "string"
             },
             {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "whenExpr": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": ["name"]
+            },
+            {
               "items": {
-                "type": "string"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "whenExpr": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "type": "object",
+                    "required": ["name"]
+                  }
+                ]
               },
               "type": "array"
             }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -8,6 +8,66 @@ import (
 	"time"
 )
 
+// loadTarget loads a config whose route "r" uses the given `target:` YAML, with
+// targets a and b defined, and returns the decoded TargetRefs (or the error).
+func loadTarget(t *testing.T, targetYAML string) (TargetRefs, error) {
+	t.Helper()
+	body := "targets:\n  a: { apprise: { url: 'pover://u@t/a' } }\n  b: { apprise: { url: 'pover://u@t/b' } }\nroutes:\n  r:\n    message: m\n    target: " + targetYAML + "\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "c.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rc, err := LoadRouteConfig(path)
+	if err != nil {
+		return nil, err
+	}
+	return rc.Routes["r"].Target, nil
+}
+
+func TestTargetRefsDecode(t *testing.T) {
+	t.Run("scalar", func(t *testing.T) {
+		got, err := loadTarget(t, "a")
+		if err != nil || len(got) != 1 || got[0].Name != "a" || got[0].WhenExpr != "" {
+			t.Fatalf("got %+v, err %v", got, err)
+		}
+	})
+	t.Run("list of names", func(t *testing.T) {
+		got, err := loadTarget(t, "[a, b]")
+		if err != nil || len(got) != 2 || got[0].Name != "a" || got[1].Name != "b" {
+			t.Fatalf("got %+v, err %v", got, err)
+		}
+	})
+	t.Run("single object", func(t *testing.T) {
+		got, err := loadTarget(t, `{ name: a, whenExpr: 'payload.x == 1' }`)
+		if err != nil || len(got) != 1 || got[0].Name != "a" || got[0].WhenExpr != "payload.x == 1" {
+			t.Fatalf("got %+v, err %v", got, err)
+		}
+	})
+	t.Run("mixed names and objects", func(t *testing.T) {
+		got, err := loadTarget(t, `[a, { name: b, whenExpr: 'payload.x == 1' }]`)
+		if err != nil {
+			t.Fatalf("err %v", err)
+		}
+		if len(got) != 2 || got[0].Name != "a" || got[0].WhenExpr != "" ||
+			got[1].Name != "b" || got[1].WhenExpr != "payload.x == 1" {
+			t.Fatalf("got %+v", got)
+		}
+	})
+	t.Run("rejections", func(t *testing.T) {
+		for _, bad := range []string{
+			`[{ name: a, bogus: 1 }]`,      // unknown key
+			`[{ whenExpr: 'true' }]`,       // missing name
+			`[{ name: a, whenExpr: [x] }]`, // non-scalar value
+			`""`,                           // empty name
+		} {
+			if _, err := loadTarget(t, bad); err == nil {
+				t.Errorf("target %q decoded without error, want rejection", bad)
+			}
+		}
+	})
+}
+
 func write(t *testing.T, path, body string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -94,7 +154,7 @@ func TestLoadFile(t *testing.T) {
 		t.Errorf("route title was altered at load: %q", got)
 	}
 	// target scalar vs list both decode.
-	if d := rc.Routes["deploy"].Target; len(d) != 2 || d[0] != "pushover" || d[1] != "ingest" {
+	if d := rc.Routes["deploy"].Target; len(d) != 2 || d[0].Name != "pushover" || d[1].Name != "ingest" {
 		t.Errorf("deploy target = %v, want [pushover ingest]", d)
 	}
 }

--- a/internal/config/routes.go
+++ b/internal/config/routes.go
@@ -34,9 +34,12 @@ func (rc *RouteConfig) TemplateSource(name string) string {
 // that are relayed to its target(s). whenExpr is the only CEL field; title,
 // message, and the params/headers values are Go templates evaluated per request.
 type Route struct {
-	// Target is one target name or a list to fan out to. Required.
-	// (`jsonschema` tags are inert at runtime — read only by cmd/schema.)
-	Target StringList `yaml:"target" jsonschema:"required"`
+	// Target is one target name, a list of names, or a list mixing names and
+	// {name, whenExpr} objects to fan out to. Required. A target's whenExpr gates
+	// that single sink, so the route fans out only to the targets whose
+	// expression matches the request. (`jsonschema` tags are inert at runtime —
+	// read only by cmd/schema.)
+	Target TargetRefs `yaml:"target" jsonschema:"required"`
 	// WhenExpr is the CEL boolean gate (default true when empty).
 	WhenExpr string `yaml:"whenExpr"`
 	// Title and Message are Go templates. Message is a pointer so an omitted
@@ -141,6 +144,82 @@ func (s *StringList) UnmarshalYAML(node *yaml.Node) error {
 	}
 	*s = list
 	return nil
+}
+
+// TargetRef is one fan-out target: a configured target name, optionally gated by
+// its own whenExpr — a CEL boolean over the same variables as the route gate. An
+// empty whenExpr always fires (whenever the route does), so a bare name behaves
+// exactly as before.
+type TargetRef struct {
+	Name     string
+	WhenExpr string
+}
+
+// TargetRefs is a route's fan-out list. It decodes a single name, a list of
+// names, or a list mixing names and {name, whenExpr} objects, so the common case
+// (`target: po` or `target: [a, b]`) stays terse.
+type TargetRefs []TargetRef
+
+// UnmarshalYAML implements the go.yaml.in/yaml/v4 node-based unmarshaler.
+func (t *TargetRefs) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode, yaml.MappingNode:
+		// A single target: a bare name or one {name, whenExpr} object.
+		ref, err := decodeTargetRef(node)
+		if err != nil {
+			return err
+		}
+		*t = TargetRefs{ref}
+		return nil
+	case yaml.SequenceNode:
+		refs := make(TargetRefs, 0, len(node.Content))
+		for _, el := range node.Content {
+			ref, err := decodeTargetRef(el)
+			if err != nil {
+				return err
+			}
+			refs = append(refs, ref)
+		}
+		*t = refs
+		return nil
+	default:
+		return fmt.Errorf("expected a target name, a list of names, or a list of {name, whenExpr} objects")
+	}
+}
+
+// decodeTargetRef reads one fan-out entry: a bare name (scalar) or a
+// {name, whenExpr} object. Unknown keys and non-scalar values are rejected, so a
+// typo'd whenExpr can't silently leave a target ungated (firing on every request).
+func decodeTargetRef(node *yaml.Node) (TargetRef, error) {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.Value == "" {
+			return TargetRef{}, fmt.Errorf("a target name must not be empty")
+		}
+		return TargetRef{Name: node.Value}, nil
+	case yaml.MappingNode:
+		var ref TargetRef
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key, val := node.Content[i], node.Content[i+1]
+			if val.Kind != yaml.ScalarNode {
+				return TargetRef{}, fmt.Errorf("target %q must be a string", key.Value)
+			}
+			switch key.Value {
+			case "name":
+				ref.Name = val.Value
+			case "whenExpr":
+				ref.WhenExpr = val.Value
+			default:
+				return TargetRef{}, fmt.Errorf("unknown target key %q (allowed: name, whenExpr)", key.Value)
+			}
+		}
+		if ref.Name == "" {
+			return TargetRef{}, fmt.Errorf("a target object requires a name")
+		}
+		return ref, nil
+	default:
+		return TargetRef{}, fmt.Errorf("a target must be a name or a {name, whenExpr} object")
+	}
 }
 
 // Duration is a time.Duration that decodes from a YAML string like "10s".

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -63,8 +63,8 @@ func (r *Route) validate(name string, targets map[string]*Target) error {
 		return fmt.Errorf("config: route %q (%s): target is required", name, r.Source)
 	}
 	for _, tn := range r.Target {
-		if _, ok := targets[tn]; !ok {
-			return fmt.Errorf("config: route %q (%s) references unknown target %q", name, r.Source, tn)
+		if _, ok := targets[tn.Name]; !ok {
+			return fmt.Errorf("config: route %q (%s) references unknown target %q", name, r.Source, tn.Name)
 		}
 	}
 	if resp := r.Response; resp != nil {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -78,6 +78,14 @@ func (e *Engine) Lookup(name string) (*Route, bool) {
 // RouteCount reports how many routes are configured (0 → the server boots idle).
 func (e *Engine) RouteCount() int { return len(e.routes) }
 
+// routeTarget pairs a resolved sink with its per-target gate. The gate (from the
+// target's whenExpr, empty ⇒ always fires) selects whether this sink receives a
+// given request, so one route can fan out to a request-dependent subset.
+type routeTarget struct {
+	sink sink.Sink
+	gate *gate.Gate
+}
+
 // Route is one compiled route.
 type Route struct {
 	name      string
@@ -87,7 +95,7 @@ type Route struct {
 	message   *render.Template // nil if omitted (verbatim forward for http)
 	params    *render.Map
 	headers   *render.Map
-	sinks     []sink.Sink
+	targets   []routeTarget
 	okStatus  int
 	skipState int
 }
@@ -123,13 +131,17 @@ func buildRoute(name string, rt *config.Route, sinks map[string]sink.Sink, set *
 		return nil, err
 	}
 
-	routeSinks := make([]sink.Sink, 0, len(rt.Target))
-	for _, tn := range rt.Target {
-		s, ok := sinks[tn]
+	targets := make([]routeTarget, 0, len(rt.Target))
+	for _, ref := range rt.Target {
+		s, ok := sinks[ref.Name]
 		if !ok {
-			return nil, fmt.Errorf("unknown target %q", tn) // defensive; config.Validate already checks
+			return nil, fmt.Errorf("unknown target %q", ref.Name) // defensive; config.Validate already checks
 		}
-		routeSinks = append(routeSinks, s)
+		tg, err := gate.Compile(ref.WhenExpr)
+		if err != nil {
+			return nil, fmt.Errorf("target %q: %w", ref.Name, err)
+		}
+		targets = append(targets, routeTarget{sink: s, gate: tg})
 	}
 
 	ok, skip := defaultOKStatus, defaultSkipStatus
@@ -145,7 +157,7 @@ func buildRoute(name string, rt *config.Route, sinks map[string]sink.Sink, set *
 	return &Route{
 		name: name, gate: g, verifier: vf,
 		title: title, message: message, params: params, headers: headers,
-		sinks: routeSinks, okStatus: ok, skipState: skip,
+		targets: targets, okStatus: ok, skipState: skip,
 	}, nil
 }
 
@@ -212,10 +224,11 @@ type Result struct {
 // verified+decoded request and returns the response Result. The deadline is the
 // caller's ctx.
 func (r *Route) Handle(ctx context.Context, in Input) Result {
-	fired, err := r.gate.Eval(ctx, gate.Input{
+	gi := gate.Input{
 		Payload: in.Payload, Headers: in.Headers, Query: in.Query,
 		Method: in.Method, Route: r.name, Now: in.Now,
-	})
+	}
+	fired, err := r.gate.Eval(ctx, gi)
 	if err != nil {
 		return Result{Status: http.StatusInternalServerError, Kind: GateError, Err: err}
 	}
@@ -228,16 +241,23 @@ func (r *Route) Handle(ctx context.Context, in Input) Result {
 		return Result{Status: r.skipState, Kind: Skipped, Reason: "gate"}
 	}
 
+	// Per-target gates pick the fan-out subset against the same variables as the
+	// route gate. A target gate fault is an operator error (→ 500), like the route.
+	matched, err := r.matchTargets(ctx, gi)
+	if err != nil {
+		return Result{Status: http.StatusInternalServerError, Kind: GateError, Err: err}
+	}
+
 	rr, err := r.renderAll(in)
 	if err != nil {
 		return Result{Status: http.StatusInternalServerError, Kind: RenderError, Err: err, Dropped: rr.dropped}
 	}
 
 	if in.DryRun {
-		return Result{Status: http.StatusOK, Kind: DryRunned, Plan: r.plan(rr, in), Dropped: rr.dropped}
+		return Result{Status: http.StatusOK, Kind: DryRunned, Plan: r.plan(rr, in, matched), Dropped: rr.dropped}
 	}
 
-	sent, err := r.fanOut(ctx, rr, in)
+	sent, err := r.fanOut(ctx, rr, in, matched)
 	if err != nil {
 		return Result{Status: http.StatusBadGateway, Kind: RelayError, Err: err, Dropped: rr.dropped}
 	}
@@ -245,6 +265,20 @@ func (r *Route) Handle(ctx context.Context, in Input) Result {
 		return Result{Status: r.skipState, Kind: Skipped, Reason: "no_targets", Dropped: rr.dropped}
 	}
 	return Result{Status: r.okStatus, Kind: Relayed, Dropped: rr.dropped}
+}
+
+// matchTargets evaluates each target's gate against gi, returning a parallel
+// mask of which targets the request fans out to. The first gate fault aborts.
+func (r *Route) matchTargets(ctx context.Context, gi gate.Input) ([]bool, error) {
+	matched := make([]bool, len(r.targets))
+	for i, t := range r.targets {
+		ok, err := t.gate.Eval(ctx, gi)
+		if err != nil {
+			return nil, fmt.Errorf("target %q: %w", t.sink.Name(), err)
+		}
+		matched[i] = ok
+	}
+	return matched, nil
 }
 
 // rendered holds a route's rendered fields for one request.
@@ -301,18 +335,22 @@ func (rr *rendered) mergeDropped(prefix string, dropped map[string]error) {
 	}
 }
 
-// fanOut relays to every non-skipped target concurrently. It returns the number
-// attempted (0 → overall skip) and the first error (→ 502). An apprise target
-// with an empty body is skipped; an http target always sends.
-func (r *Route) fanOut(ctx context.Context, rr rendered, in Input) (int, error) {
+// fanOut relays to every gate-matched, non-skipped target concurrently. It
+// returns the number attempted (0 → overall skip) and the first error (→ 502). A
+// target whose whenExpr is false is skipped; an apprise target with an empty body
+// is skipped; an http target always sends.
+func (r *Route) fanOut(ctx context.Context, rr rendered, in Input, matched []bool) (int, error) {
 	type job struct {
 		s   sink.Sink
 		msg sink.Message
 	}
 	var jobs []job
-	for _, s := range r.sinks {
-		if msg, ok := messageFor(s, rr, in); ok {
-			jobs = append(jobs, job{s, msg})
+	for i, t := range r.targets {
+		if !matched[i] {
+			continue
+		}
+		if msg, ok := messageFor(t.sink, rr, in); ok {
+			jobs = append(jobs, job{t.sink, msg})
 		}
 	}
 	if len(jobs) == 0 {
@@ -365,11 +403,11 @@ type PlanTarget struct {
 	Skipped bool              `json:"skipped,omitempty"`
 }
 
-func (r *Route) plan(rr rendered, in Input) *Plan {
+func (r *Route) plan(rr rendered, in Input, matched []bool) *Plan {
 	p := &Plan{Route: r.name, Fired: true}
-	for _, s := range r.sinks {
-		pt := PlanTarget{Name: s.Name(), Kind: s.Kind()}
-		if msg, ok := messageFor(s, rr, in); ok {
+	for i, t := range r.targets {
+		pt := PlanTarget{Name: t.sink.Name(), Kind: t.sink.Kind()}
+		if msg, ok := messageFor(t.sink, rr, in); ok && matched[i] {
 			pt.Title, pt.Body, pt.Params, pt.Headers = msg.Title, msg.Body, msg.Params, msg.Headers
 		} else {
 			pt.Skipped = true

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -143,6 +143,108 @@ routes: { r: { target: po, message: '{{ template "loop" . }}' } }
 	}
 }
 
+const perTargetWhenExpr = `
+targets:
+  a: { apprise: { url: 'pover://u@t/a' } }
+  b: { apprise: { url: 'pover://u@t/b' } }
+routes:
+  r:
+    message: 'm'
+    target:
+      - { name: a, whenExpr: 'payload.to == "a"' }
+      - { name: b, whenExpr: 'payload.to == "b"' }
+`
+
+// planTarget finds a named target in a dry-run plan.
+func planTarget(t *testing.T, p *relay.Plan, name string) relay.PlanTarget {
+	t.Helper()
+	for _, pt := range p.Targets {
+		if pt.Name == name {
+			return pt
+		}
+	}
+	t.Fatalf("target %q not in plan %+v", name, p.Targets)
+	return relay.PlanTarget{}
+}
+
+// TestPerTargetWhenExpr pins per-target conditional fan-out: a single route
+// delivers only to the targets whose own whenExpr matches the request.
+func TestPerTargetWhenExpr(t *testing.T) {
+	r := route(t, engine(t, perTargetWhenExpr, &fakeNotifier{}))
+
+	// Dry run for {to:a}: target a fires, target b is skipped.
+	res := handle(r, map[string]any{"to": "a"}, true)
+	if res.Kind != relay.DryRunned {
+		t.Fatalf("kind=%v err=%v, want DryRunned", res.Kind, res.Err)
+	}
+	if got := planTarget(t, res.Plan, "a"); got.Skipped {
+		t.Errorf("target a skipped for to=a, want delivered")
+	}
+	if got := planTarget(t, res.Plan, "b"); !got.Skipped {
+		t.Errorf("target b delivered for to=a, want skipped")
+	}
+
+	// Live: exactly one target (a) is sent to.
+	fn := &fakeNotifier{}
+	r = route(t, engine(t, perTargetWhenExpr, fn))
+	if res := handle(r, map[string]any{"to": "a"}, false); res.Kind != relay.Relayed {
+		t.Fatalf("kind=%v err=%v, want Relayed", res.Kind, res.Err)
+	}
+	if fn.calls != 1 {
+		t.Errorf("sends = %d, want 1 (only target a)", fn.calls)
+	}
+}
+
+// TestPerTargetWhenExprNoneMatch: route fires but no target matches ⇒ skip.
+func TestPerTargetWhenExprNoneMatch(t *testing.T) {
+	fn := &fakeNotifier{}
+	r := route(t, engine(t, perTargetWhenExpr, fn))
+	res := handle(r, map[string]any{"to": "nobody"}, false)
+	if res.Kind != relay.Skipped || res.Reason != "no_targets" {
+		t.Fatalf("kind=%v reason=%q, want Skipped/no_targets", res.Kind, res.Reason)
+	}
+	if fn.calls != 0 {
+		t.Errorf("sends = %d, want 0", fn.calls)
+	}
+}
+
+// TestPerTargetWhenExprError: a target gate fault is an operator error ⇒ 500.
+func TestPerTargetWhenExprError(t *testing.T) {
+	const y = `
+targets:
+  a: { apprise: { url: 'pover://u@t/a' } }
+routes:
+  r:
+    message: 'm'
+    target:
+      - { name: a, whenExpr: 'payload.items[5] == "x"' }
+`
+	r := route(t, engine(t, y, &fakeNotifier{}))
+	res := handle(r, map[string]any{"items": []any{}}, false)
+	if res.Kind != relay.GateError || res.Status != 500 {
+		t.Fatalf("kind=%v status=%d, want GateError/500", res.Kind, res.Status)
+	}
+}
+
+// TestStaticFanoutUnchanged: a bare target list still fans out to all targets.
+func TestStaticFanoutUnchanged(t *testing.T) {
+	const y = `
+targets:
+  a: { apprise: { url: 'pover://u@t/a' } }
+  b: { apprise: { url: 'pover://u@t/b' } }
+routes:
+  r: { message: 'm', target: [a, b] }
+`
+	fn := &fakeNotifier{}
+	r := route(t, engine(t, y, fn))
+	if res := handle(r, map[string]any{}, false); res.Kind != relay.Relayed {
+		t.Fatalf("kind=%v, want Relayed", res.Kind)
+	}
+	if fn.calls != 2 {
+		t.Errorf("sends = %d, want 2 (both targets)", fn.calls)
+	}
+}
+
 func TestGateSkips(t *testing.T) {
 	fn := &fakeNotifier{}
 	r := route(t, engine(t, apprise1, fn))


### PR DESCRIPTION
Implements the "dynamic fanout targets" ask from Discord (bo0tzz): a single inbound webhook fans out only to the targets whose own condition matches — for mirroring GitHub/Discord webhooks to the right dev instance.

## What

A route's `target` entry can now be a `{ name, whenExpr }` object as well as a bare name. The `whenExpr` is a CEL boolean over the **same variables as the route gate** (`payload`, `headers`, `query`, `method`, `route`, `now`) and gates that one target:

```yaml
routes:
  github:
    whenExpr: payload.repository.full_name == "immich-app/immich"  # optional route prefilter
    target:
      - prod-notify                                                # bare name ⇒ always (when the route fires)
      - { name: dev-alice, whenExpr: 'payload.sender.login == "alice"' }
      - { name: dev-bob,   whenExpr: 'payload.pull_request.draft == false' }
```

- The route gate fires the route as a whole; then each target's gate selects the subset that receives the rendered fields.
- A **bare name or empty `whenExpr` always fires**, so existing `target: x` / `target: [a, b]` configs behave exactly as before.
- Route fires but **no target matches** ⇒ skipped (`no_targets`). A **target-gate fault** is an operator error (500), like the route gate.
- Target names/URLs stay **config-defined, never payload-derived** (the SSRF boundary is unchanged).

## How

- `config.TargetRefs` decodes a scalar, a list of names, or a list mixing names and `{name, whenExpr}` objects. Unknown keys and non-scalar values are rejected, so a typo'd `whenExpr` can't silently leave a target ungated (firing on every request).
- Each target compiles its own `gate.Gate`; `Route.Handle` evaluates them per request and threads the match-set through fan-out and the dry-run plan (a gated-out target shows `skipped` in `?dryRun=1`).
- Regenerated `config.schema.json` (target item is now `string | {name, whenExpr}`); README + `chaski validate` summary updated (a gated target is marked `name?`).

## Verified

Tests: decoding (scalar / list / mixed / rejections), per-target selection (dry-run plan + live send count), none-match skip, gate-fault 500, and that a bare list still fans out to all. `go test -race ./...`, `golangci-lint` (0), `gofmt`, `generate-check`, `helm lint`/`unittest` all green. CLI dry-run confirms the gated subset end-to-end.

cc @bo0tzz — this covers the conditional-fanout half; the zero-config "mirror to whatever dev instance appeared" part is still best served by a tunnel into a configured `http` target (payload-derived endpoints stay out, by design).
