### PR TITLE
fix(config): tighten route target validation

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -184,7 +184,12 @@ func decodeFragment(data []byte, name string) (*RouteConfig, error) {
 	var rc RouteConfig
 	// Strict decoding: an unknown/typo'd key is an error, not a silent no-op.
 	if err := yaml.Load(data, &rc, yaml.WithKnownFields()); err != nil {
-		return nil, fmt.Errorf("config: parsing %q: %w (multi-document files are not supported — split into separate files)", name, err)
+		// The split-files hint only applies to the multi-document error; don't
+		// append it to unrelated parse errors (a typo, bad indentation, …).
+		if strings.Contains(err.Error(), "expected single document") {
+			return nil, fmt.Errorf("config: %q has multiple YAML documents; split them into separate files", name)
+		}
+		return nil, fmt.Errorf("config: parsing %q: %w", name, err)
 	}
 
 	for _, r := range rc.Routes {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -60,6 +60,7 @@ func TestTargetRefsDecode(t *testing.T) {
 			`[{ whenExpr: 'true' }]`,       // missing name
 			`[{ name: a, whenExpr: [x] }]`, // non-scalar value
 			`""`,                           // empty name
+			`[{ name: a, name: b }]`,       // duplicate key
 		} {
 			if _, err := loadTarget(t, bad); err == nil {
 				t.Errorf("target %q decoded without error, want rejection", bad)
@@ -202,6 +203,16 @@ func TestDuplicateNamesAreFatal(t *testing.T) {
 	}
 }
 
+func TestDuplicateTargetInRouteRejected(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, "c.yaml"),
+		"targets:\n  x: {apprise: {url: 'pover://u@t/'}}\nroutes:\n  r:\n    message: m\n    target:\n      - { name: x, whenExpr: 'payload.a' }\n      - { name: x, whenExpr: 'payload.b' }\n")
+	_, err := LoadRouteConfig(dir)
+	if err == nil || !strings.Contains(err.Error(), "more than once") {
+		t.Fatalf("err = %v, want a duplicate-target error guiding to one whenExpr", err)
+	}
+}
+
 func TestSinkValidation(t *testing.T) {
 	tests := map[string]string{
 		"both sinks":     "targets:\n  x: {apprise: {url: 'pover://u@t/'}, http: {url: 'https://h'}}\n",
@@ -233,8 +244,23 @@ func TestMissingEnvVarIsFatal(t *testing.T) {
 func TestMultiDocumentRejected(t *testing.T) {
 	dir := t.TempDir()
 	write(t, filepath.Join(dir, "c.yaml"), "targets:\n  a: {apprise: {url: 'pover://u@t/'}}\n---\ntargets:\n  b: {apprise: {url: 'pover://u@t/'}}\n")
-	if _, err := LoadRouteConfig(dir); err == nil {
-		t.Fatal("expected error for multi-document file")
+	_, err := LoadRouteConfig(dir)
+	if err == nil || !strings.Contains(err.Error(), "multiple YAML documents") {
+		t.Fatalf("err = %v, want a multi-document error", err)
+	}
+}
+
+// TestParseErrorHasNoMultiDocSuffix: a plain syntax error must not be tagged
+// with the (multi-document) hint that only applies to multi-document files.
+func TestParseErrorHasNoMultiDocSuffix(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, "c.yaml"), "targets:\n  a: {apprise: {url: 'pover://u@t/'}}\n bad: indentation\n")
+	_, err := LoadRouteConfig(dir)
+	if err == nil {
+		t.Fatal("expected a parse error")
+	}
+	if strings.Contains(err.Error(), "multi") || strings.Contains(err.Error(), "split") {
+		t.Errorf("plain parse error carries the multi-document hint: %v", err)
 	}
 }
 

--- a/internal/config/routes.go
+++ b/internal/config/routes.go
@@ -199,8 +199,13 @@ func decodeTargetRef(node *yaml.Node) (TargetRef, error) {
 		return TargetRef{Name: node.Value}, nil
 	case yaml.MappingNode:
 		var ref TargetRef
+		seen := make(map[string]bool, 2)
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			key, val := node.Content[i], node.Content[i+1]
+			if seen[key.Value] {
+				return TargetRef{}, fmt.Errorf("duplicate target key %q", key.Value)
+			}
+			seen[key.Value] = true
 			if val.Kind != yaml.ScalarNode {
 				return TargetRef{}, fmt.Errorf("target %q must be a string", key.Value)
 			}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -62,10 +62,17 @@ func (r *Route) validate(name string, targets map[string]*Target) error {
 	if len(r.Target) == 0 {
 		return fmt.Errorf("config: route %q (%s): target is required", name, r.Source)
 	}
+	seen := make(map[string]bool, len(r.Target))
 	for _, tn := range r.Target {
 		if _, ok := targets[tn.Name]; !ok {
 			return fmt.Errorf("config: route %q (%s) references unknown target %q", name, r.Source, tn.Name)
 		}
+		if seen[tn.Name] {
+			// Two entries for one sink would deliver to it twice; with per-target
+			// whenExpr that reads like an OR but double-sends when both match.
+			return fmt.Errorf("config: route %q (%s) lists target %q more than once; combine the conditions into one whenExpr (a || b)", name, r.Source, tn.Name)
+		}
+		seen[tn.Name] = true
 	}
 	if resp := r.Response; resp != nil {
 		if err := validateStatus(resp.Status, name, r.Source, "status"); err != nil {


### PR DESCRIPTION
Follow-up to #18 (per-target `whenExpr`), addressing findings from a post-merge review.

- **Reject a duplicate target name in one route's fan-out.** Two entries for the same sink deliver to it twice; with per-target `whenExpr`, `[{name: a, whenExpr: X}, {name: a, whenExpr: Y}]` *reads* like "fire if X **or** Y" but actually double-sends when both match. Now a load-time error pointing at a single `whenExpr: X || Y`. (The double-send was pre-existing for `target: [a, a]`; the new expressiveness just makes it tempting.)
- **Reject a duplicate key inside a `{name, whenExpr}` object.** The hand-rolled decoder was silently last-wins; now it errors, matching the strict decoding the loader enforces for every other field.
- **Stop tagging every parse error with the multi-document hint.** `config: parsing "x": … (multi-document files are not supported …)` was appended to *all* YAML errors — a typo or bad indentation read as a multi-doc problem. The hint now shows only for the actual multi-document error.

No behavior change for valid configs (distinct target names, single docs). Tests cover each rejection and the clean error messages. `go test -race ./...`, `golangci-lint` (0), `gofmt`, `generate-check`, all green; config-only, no schema/chart change.
