### PR TITLE
feat(server)!: serve webhooks at /hooks/{route}

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ plain HTTP request.
 
 ## Features
 
-- **Routing by path** — `POST /notify/{route}`; each route is configured
+- **Routing by path** — `POST /hooks/{route}`; each route is configured
   independently and can fan out to several targets concurrently, optionally
   gating each target with its own `whenExpr`.
 - **CEL gate** — a per-route `whenExpr` decides whether a request is relayed.
@@ -59,7 +59,7 @@ token (see [Configuration](#configuration)):
 ```sh
 CHASKI_CONFIG=./chaski.yaml chaski
 
-curl -X POST http://localhost:8080/notify/alertmanager \
+curl -X POST http://localhost:8080/hooks/alertmanager \
   -H "Content-Type: application/json" \
   -d '{"status":"firing","commonLabels":{"severity":"critical","alertname":"HighCPU"}}'
 ```

--- a/charts/chaski/README.md
+++ b/charts/chaski/README.md
@@ -84,7 +84,7 @@ Kubernetes: `>=1.25.0-0`
 | config.requestTimeout | string | `"15s"` | Whole-request deadline (CHASKI_REQUEST_TIMEOUT): decode + gate + render + send + retry. |
 | config.retryAttempts | int | `3` | Global default retry attempts per target (CHASKI_RETRY_ATTEMPTS); a target's `retry.attempts` overrides it. |
 | config.retryBackoff | string | `"200ms"` | Global default retry base backoff (CHASKI_RETRY_BACKOFF); a target's `retry.backoff` overrides it. |
-| config.routes | object | `{}` | Route definitions, keyed by name (the URL path: POST /notify/{name}). Emitted verbatim into the ConfigMap — `{{ ... }}` here is chaski's CEL/Go-template syntax, not Helm's. See config.schema.json for the field reference. |
+| config.routes | object | `{}` | Route definitions, keyed by name (the URL path: POST /hooks/{name}). Emitted verbatim into the ConfigMap — `{{ ... }}` here is chaski's CEL/Go-template syntax, not Helm's. See config.schema.json for the field reference. |
 | config.smtpEnabled | bool | `false` | Accept notifications over SMTP, relaying by the recipient localpart (sonarr@… → the route named `sonarr`). Off by default — it is an inbound relay path, so opt in explicitly (CHASKI_SMTP_ENABLED). When on, set `auth.smtpAuth` and keep the listener on a trusted network (v1 has no TLS). |
 | config.smtpHostname | string | `"chaski"` | Hostname announced in the SMTP greeting (CHASKI_SMTP_HOSTNAME). |
 | config.smtpMaxMessageBytes | int | `1048576` | Max inbound message size in bytes (CHASKI_SMTP_MAX_MESSAGE_BYTES). |

--- a/charts/chaski/templates/NOTES.txt
+++ b/charts/chaski/templates/NOTES.txt
@@ -32,13 +32,13 @@ Send a webhook from inside the cluster (replace <route>):
   kubectl -n {{ .Release.Namespace }} run chaski-curl --rm -it --restart=Never --image=curlimages/curl -- \
     curl -fsS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
       --data '{"status":"firing"}' \
-      "http://{{ include "chaski.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/notify/<route>?dryRun=1"
+      "http://{{ include "chaski.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/hooks/<route>?dryRun=1"
 {{- else }}
 
   kubectl -n {{ .Release.Namespace }} run chaski-curl --rm -it --restart=Never --image=curlimages/curl -- \
     curl -fsS -X POST -H "Content-Type: application/json" \
       --data '{"status":"firing"}' \
-      "http://{{ include "chaski.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/notify/<route>?dryRun=1"
+      "http://{{ include "chaski.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/hooks/<route>?dryRun=1"
 {{- end }}
 
 Validate the config (the same checks chaski runs at boot):

--- a/charts/chaski/values.schema.json
+++ b/charts/chaski/values.schema.json
@@ -115,7 +115,7 @@
           "type": "string"
         },
         "routes": {
-          "description": "Route definitions, keyed by name (the URL path: POST /notify/{name}). Emitted verbatim into the ConfigMap — `{{ ... }}` here is chaski's CEL/Go-template syntax, not Helm's. See config.schema.json for the field reference.",
+          "description": "Route definitions, keyed by name (the URL path: POST /hooks/{name}). Emitted verbatim into the ConfigMap — `{{ ... }}` here is chaski's CEL/Go-template syntax, not Helm's. See config.schema.json for the field reference.",
           "required": [],
           "title": "routes",
           "type": "object"

--- a/charts/chaski/values.yaml
+++ b/charts/chaski/values.yaml
@@ -72,7 +72,7 @@ config:
   # -- Mount this existing ConfigMap instead of rendering one from `routes`/`targets` (e.g. for a config.d directory of fragments). Set `configPath` to `/config` for directory mode.
   existingConfigMap: ""
 
-  # -- Route definitions, keyed by name (the URL path: POST /notify/{name}). Emitted verbatim into the ConfigMap — `{{ ... }}` here is chaski's CEL/Go-template syntax, not Helm's. See config.schema.json for the field reference.
+  # -- Route definitions, keyed by name (the URL path: POST /hooks/{name}). Emitted verbatim into the ConfigMap — `{{ ... }}` here is chaski's CEL/Go-template syntax, not Helm's. See config.schema.json for the field reference.
   routes: {}
   #   alertmanager:
   #     target: pushover

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ const DefaultConfigPath = "/config/chaski.yaml"
 // are populated by env.Parse; LogLevel is derived in Load so its parsing fails
 // fast with a clear message.
 type Config struct {
-	// HTTPPort is the public webhook receiver (POST /notify/{route}).
+	// HTTPPort is the public webhook receiver (POST /hooks/{route}).
 	HTTPPort int `env:"CHASKI_PORT" envDefault:"8080"`
 
 	// MetricsEnabled exposes Prometheus metrics at /metrics and the /healthz

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -13,14 +13,14 @@ import (
 	"github.com/home-operations/chaski/internal/relay"
 )
 
-// handler builds the public webhook mux: POST /notify/{route} (+ ?dryRun=1),
+// handler builds the public webhook mux: POST /hooks/{route} (+ ?dryRun=1),
 // everything else 404. Middleware adds metrics, security headers, and panic
 // recovery.
 func (s *Server) handler() http.Handler {
 	mux := http.NewServeMux()
-	// Registered method-agnostic (not "POST /notify/{route}") so a non-POST gets
+	// Registered method-agnostic (not "POST /hooks/{route}") so a non-POST gets
 	// an explicit 405 rather than being swallowed by the "/" catch-all's 404.
-	mux.HandleFunc("/notify/{route}", s.handleNotify)
+	mux.HandleFunc("/hooks/{route}", s.handleHook)
 	mux.HandleFunc("/", handleNotFound)
 
 	var h http.Handler = mux
@@ -38,9 +38,9 @@ func handleHealth(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
-// handleNotify runs the inbound pipeline: token auth → route lookup → body cap →
+// handleHook runs the inbound pipeline: token auth → route lookup → body cap →
 // signature verify → decode → relay, then maps the result to a status.
-func (s *Server) handleNotify(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleHook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		webhookRejected.WithLabelValues("method").Inc()

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -18,9 +18,9 @@ func TestWebhookRejectedMetric(t *testing.T) {
 		target  string
 		body    string
 	}{
-		{"unauthorized", map[string]string{"Content-Type": jsonCT}, "/notify/alertmanager", `{}`},
-		{"not_found", authed, "/notify/ghost", `{}`},
-		{"decode", map[string]string{"Content-Type": "text/plain", "Authorization": "Bearer tok"}, "/notify/alertmanager", "hi"},
+		{"unauthorized", map[string]string{"Content-Type": jsonCT}, "/hooks/alertmanager", `{}`},
+		{"not_found", authed, "/hooks/ghost", `{}`},
+		{"decode", map[string]string{"Content-Type": "text/plain", "Authorization": "Bearer tok"}, "/hooks/alertmanager", "hi"},
 	}
 	for _, c := range cases {
 		t.Run(c.reason, func(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -110,14 +110,14 @@ func TestMetricsEndpoint(t *testing.T) {
 }
 
 func TestUnknownRouteIs404(t *testing.T) {
-	rec := do(newServer(emptyEngine(t), ""), http.MethodPost, "/notify/nope", "{}", map[string]string{"Content-Type": jsonCT})
+	rec := do(newServer(emptyEngine(t), ""), http.MethodPost, "/hooks/nope", "{}", map[string]string{"Content-Type": jsonCT})
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", rec.Code)
 	}
 }
 
 func TestNonPostIs405(t *testing.T) {
-	rec := do(newServer(emptyEngine(t), ""), http.MethodGet, "/notify/x", "", nil)
+	rec := do(newServer(emptyEngine(t), ""), http.MethodGet, "/hooks/x", "", nil)
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("status = %d, want 405", rec.Code)
 	}
@@ -127,13 +127,13 @@ func TestTokenAuth(t *testing.T) {
 	srv := newServer(engineWithRoute(t, &fakeNotifier{}), "s3cr3t")
 	body := `{"status":"firing"}`
 
-	if rec := do(srv, http.MethodPost, "/notify/alertmanager", body, map[string]string{"Content-Type": jsonCT}); rec.Code != http.StatusUnauthorized {
+	if rec := do(srv, http.MethodPost, "/hooks/alertmanager", body, map[string]string{"Content-Type": jsonCT}); rec.Code != http.StatusUnauthorized {
 		t.Errorf("no token: status = %d, want 401", rec.Code)
 	}
-	if rec := do(srv, http.MethodPost, "/notify/alertmanager", body, map[string]string{"Content-Type": jsonCT, "Authorization": "Bearer wrong"}); rec.Code != http.StatusUnauthorized {
+	if rec := do(srv, http.MethodPost, "/hooks/alertmanager", body, map[string]string{"Content-Type": jsonCT, "Authorization": "Bearer wrong"}); rec.Code != http.StatusUnauthorized {
 		t.Errorf("wrong token: status = %d, want 401", rec.Code)
 	}
-	if rec := do(srv, http.MethodPost, "/notify/alertmanager", body, map[string]string{"Content-Type": jsonCT, "Authorization": "Bearer s3cr3t"}); rec.Code != http.StatusOK {
+	if rec := do(srv, http.MethodPost, "/hooks/alertmanager", body, map[string]string{"Content-Type": jsonCT, "Authorization": "Bearer s3cr3t"}); rec.Code != http.StatusOK {
 		t.Errorf("correct token: status = %d, want 200", rec.Code)
 	}
 }
@@ -143,7 +143,7 @@ func TestTokenAuth(t *testing.T) {
 // (the common case for cluster-internal senders).
 func TestNoTokenConfiguredAcceptsUnauthenticated(t *testing.T) {
 	srv := newServer(engineWithRoute(t, &fakeNotifier{}), "")
-	rec := do(srv, http.MethodPost, "/notify/alertmanager", `{"status":"firing"}`,
+	rec := do(srv, http.MethodPost, "/hooks/alertmanager", `{"status":"firing"}`,
 		map[string]string{"Content-Type": jsonCT})
 	if rec.Code != http.StatusOK {
 		t.Errorf("no token configured: status = %d, want 200 (auth disabled)", rec.Code)
@@ -154,10 +154,10 @@ func TestRelayAndSkipStatuses(t *testing.T) {
 	fn := &fakeNotifier{}
 	srv := newServer(engineWithRoute(t, fn), "")
 
-	if rec := do(srv, http.MethodPost, "/notify/alertmanager", `{"status":"firing"}`, map[string]string{"Content-Type": jsonCT}); rec.Code != http.StatusOK {
+	if rec := do(srv, http.MethodPost, "/hooks/alertmanager", `{"status":"firing"}`, map[string]string{"Content-Type": jsonCT}); rec.Code != http.StatusOK {
 		t.Errorf("firing: status = %d, want 200", rec.Code)
 	}
-	if rec := do(srv, http.MethodPost, "/notify/alertmanager", `{"status":"resolved"}`, map[string]string{"Content-Type": jsonCT}); rec.Code != http.StatusNoContent {
+	if rec := do(srv, http.MethodPost, "/hooks/alertmanager", `{"status":"resolved"}`, map[string]string{"Content-Type": jsonCT}); rec.Code != http.StatusNoContent {
 		t.Errorf("resolved: status = %d, want 204", rec.Code)
 	}
 	if fn.calls != 1 {
@@ -168,7 +168,7 @@ func TestRelayAndSkipStatuses(t *testing.T) {
 func TestDryRunReturnsPlanWithoutSending(t *testing.T) {
 	fn := &fakeNotifier{}
 	srv := newServer(engineWithRoute(t, fn), "")
-	rec := do(srv, http.MethodPost, "/notify/alertmanager?dryRun=1", `{"status":"firing"}`, map[string]string{"Content-Type": jsonCT})
+	rec := do(srv, http.MethodPost, "/hooks/alertmanager?dryRun=1", `{"status":"firing"}`, map[string]string{"Content-Type": jsonCT})
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
@@ -184,11 +184,11 @@ func TestDryRunReturnsPlanWithoutSending(t *testing.T) {
 func TestResultHeader(t *testing.T) {
 	srv := newServer(engineWithRoute(t, &fakeNotifier{}), "")
 
-	rec := do(srv, http.MethodPost, "/notify/alertmanager", `{"status":"firing"}`, map[string]string{"Content-Type": jsonCT})
+	rec := do(srv, http.MethodPost, "/hooks/alertmanager", `{"status":"firing"}`, map[string]string{"Content-Type": jsonCT})
 	if got := rec.Header().Get("X-Chaski-Result"); got != "relayed" {
 		t.Errorf("relayed header = %q, want relayed", got)
 	}
-	rec = do(srv, http.MethodPost, "/notify/alertmanager", `{"status":"resolved"}`, map[string]string{"Content-Type": jsonCT})
+	rec = do(srv, http.MethodPost, "/hooks/alertmanager", `{"status":"resolved"}`, map[string]string{"Content-Type": jsonCT})
 	if got := rec.Header().Get("X-Chaski-Result"); got != "skipped:gate" {
 		t.Errorf("gate-false header = %q, want skipped:gate", got)
 	}
@@ -196,7 +196,7 @@ func TestResultHeader(t *testing.T) {
 
 func TestDryRunGateFalseReturnsPlan(t *testing.T) {
 	srv := newServer(engineWithRoute(t, &fakeNotifier{}), "")
-	rec := do(srv, http.MethodPost, "/notify/alertmanager?dryRun=1", `{"status":"resolved"}`, map[string]string{"Content-Type": jsonCT})
+	rec := do(srv, http.MethodPost, "/hooks/alertmanager?dryRun=1", `{"status":"resolved"}`, map[string]string{"Content-Type": jsonCT})
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (gate-false dry run still previews)", rec.Code)
@@ -226,7 +226,7 @@ routes:
 	}
 	srv := newServer(e, "")
 
-	rec := do(srv, http.MethodPost, "/notify/r", `{"x":"scalar"}`, map[string]string{"Content-Type": jsonCT})
+	rec := do(srv, http.MethodPost, "/hooks/r", `{"x":"scalar"}`, map[string]string{"Content-Type": jsonCT})
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500", rec.Code)
 	}
@@ -241,7 +241,7 @@ routes:
 
 func TestUnsupportedContentTypeIs400(t *testing.T) {
 	srv := newServer(engineWithRoute(t, &fakeNotifier{}), "")
-	rec := do(srv, http.MethodPost, "/notify/alertmanager", "hello", map[string]string{"Content-Type": "text/plain"})
+	rec := do(srv, http.MethodPost, "/hooks/alertmanager", "hello", map[string]string{"Content-Type": "text/plain"})
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rec.Code)
 	}

--- a/internal/server/token_test.go
+++ b/internal/server/token_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestInboundToken(t *testing.T) {
 	t.Run("bearer header", func(t *testing.T) {
-		r := httptest.NewRequest(http.MethodPost, "/notify/x", nil)
+		r := httptest.NewRequest(http.MethodPost, "/hooks/x", nil)
 		r.Header.Set("Authorization", "Bearer abc")
 		if got := inboundToken(r); got != "abc" {
 			t.Errorf("token = %q, want abc", got)
@@ -16,14 +16,14 @@ func TestInboundToken(t *testing.T) {
 	})
 
 	t.Run("query fallback when no bearer header", func(t *testing.T) {
-		r := httptest.NewRequest(http.MethodPost, "/notify/x?token=q123", nil)
+		r := httptest.NewRequest(http.MethodPost, "/hooks/x?token=q123", nil)
 		if got := inboundToken(r); got != "q123" {
 			t.Errorf("token = %q, want q123", got)
 		}
 	})
 
 	t.Run("none present", func(t *testing.T) {
-		r := httptest.NewRequest(http.MethodPost, "/notify/x", nil)
+		r := httptest.NewRequest(http.MethodPost, "/hooks/x", nil)
 		if got := inboundToken(r); got != "" {
 			t.Errorf("token = %q, want empty", got)
 		}


### PR DESCRIPTION
**Breaking change.** Renames the inbound webhook path prefix from `/notify/{route}` to `/hooks/{route}`.

`/notify` framed chaski as a notifications endpoint, but it's a generic webhook relay — it gates/enriches arbitrary JSON and forwards to plain HTTP targets as readily as to apprise notifications. `/hooks` reflects that. The route-name segment is unchanged.

## Changes
- `internal/server/handler.go`: mux route `/notify/{route}` → `/hooks/{route}`; `handleNotify` → `handleHook`.
- Docs: README (`POST /hooks/{route}`, curl example), `values.yaml` routes comment, regenerated chart `README.md` + `values.schema.json`, chart `NOTES.txt`.
- `internal/config/config.go` doc comment; server tests (`server_test.go`, `metrics_test.go`, `token_test.go`).

## BREAKING CHANGE
Webhook senders must POST to **`/hooks/{route}`**; `/notify/{route}` now returns 404. Update sender URLs (the post-install NOTES already show the new path). No alias is kept — clean break, pre-1.0.

`go test -race ./...`, `golangci-lint` (0), `gofmt`, `generate-check`, `helm lint`/`unittest` (19/19) all green.
