### PR TITLE
feat(config): self-documenting schema + route/target descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,19 +311,27 @@ Attachments are not forwarded.
 Routes and targets are loaded from `CHASKI_CONFIG`; operational settings come
 from the environment:
 
-| Variable                 | Default               | Description                                    |
-| ------------------------ | --------------------- | ---------------------------------------------- |
-| `CHASKI_CONFIG`          | `/config/chaski.yaml` | Route config file or `config.d` directory      |
-| `CHASKI_WEBHOOK_TOKEN`   | _(none)_              | Optional inbound bearer token; unset = no auth |
-| `CHASKI_PORT`            | `8080`                | Webhook listener                               |
-| `CHASKI_METRICS_PORT`    | `8081`                | Metrics + health listener                      |
-| `CHASKI_MAX_BODY_BYTES`  | `1048576`             | Inbound body size cap                          |
-| `CHASKI_REQUEST_TIMEOUT` | `15s`                 | Whole-request deadline                         |
-| `CHASKI_RETRY_ATTEMPTS`  | `3`                   | Default per-target retry attempts              |
-| `CHASKI_RETRY_BACKOFF`   | `200ms`               | Default retry backoff (exponential)            |
-| `CHASKI_SMTP_ENABLED`    | `false`               | Enable the SMTP ingestion listener             |
-| `CHASKI_SMTP_PORT`       | `8025`                | SMTP listener port (when enabled)              |
-| `CHASKI_SMTP_AUTH`       | _(none)_              | `user:password,…` list; set ⇒ require AUTH     |
+| Variable                        | Default               | Description                                              |
+| ------------------------------- | --------------------- | -------------------------------------------------------- |
+| `CHASKI_CONFIG`                 | `/config/chaski.yaml` | Route config file or `config.d` directory                |
+| `CHASKI_WEBHOOK_TOKEN`          | _(none)_              | Optional inbound bearer token; unset = no auth           |
+| `CHASKI_PORT`                   | `8080`                | Webhook listener (`POST /hooks/{route}`)                 |
+| `CHASKI_MAX_BODY_BYTES`         | `1048576`             | Inbound body size cap                                    |
+| `CHASKI_REQUEST_TIMEOUT`        | `15s`                 | Whole-request deadline (overridden per target `timeout`) |
+| `CHASKI_RETRY_ATTEMPTS`         | `3`                   | Default per-target retry attempts (target `retry` wins)  |
+| `CHASKI_RETRY_BACKOFF`          | `200ms`               | Default retry backoff (overridden per target `retry`)    |
+| `CHASKI_METRICS_ENABLED`        | `true`                | Serve `/metrics` + `/healthz` on the metrics port        |
+| `CHASKI_METRICS_PORT`           | `8081`                | Metrics + health listener                                |
+| `CHASKI_LOG_LEVEL`              | `info`                | `debug` \| `info` \| `warn` \| `error`                   |
+| `CHASKI_LOG_FORMAT`             | `json`                | slog handler: `json` or `text`                           |
+| `CHASKI_DISABLE_REQUEST_LOGS`   | `false`               | Silence the per-request access log                       |
+| `CHASKI_SHUTDOWN_TIMEOUT`       | `15s`                 | Graceful drain bound on SIGINT/SIGTERM                   |
+| `CHASKI_SMTP_ENABLED`           | `false`               | Enable the SMTP ingestion listener                       |
+| `CHASKI_SMTP_PORT`              | `8025`                | SMTP listener port (when enabled)                        |
+| `CHASKI_SMTP_AUTH`              | _(none)_              | `user:password,…` list; set ⇒ require AUTH               |
+| `CHASKI_SMTP_HOSTNAME`          | `chaski`              | Name announced in the SMTP greeting                      |
+| `CHASKI_SMTP_MAX_MESSAGE_BYTES` | `1048576`             | Inbound SMTP message size cap                            |
+| `CHASKI_SMTP_MAX_RECIPIENTS`    | `50`                  | Max recipients per SMTP message                          |
 
 A JSON Schema for the route config is published at
 [`config.schema.json`](config.schema.json) — point your editor's YAML language

--- a/cmd/chaski/validate.go
+++ b/cmd/chaski/validate.go
@@ -149,10 +149,16 @@ func printSummary(w io.Writer, path string, rc *config.RouteConfig) {
 	for _, name := range slices.Sorted(maps.Keys(rc.Routes)) {
 		r := rc.Routes[name]
 		p("  route %-24s (%s) → %v\n", name, r.Source, targetNames(r.Target))
+		if r.Description != "" {
+			p("      %s\n", r.Description)
+		}
 	}
 	for _, name := range slices.Sorted(maps.Keys(rc.Targets)) {
 		t := rc.Targets[name]
 		p("  target %-23s (%s) [%s]\n", name, t.Source, t.Kind())
+		if t.Description != "" {
+			p("      %s\n", t.Description)
+		}
 	}
 	for _, name := range slices.Sorted(maps.Keys(rc.Templates)) {
 		p("  template %-21s (%s)\n", name, rc.TemplateSource(name))

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -30,6 +30,13 @@ func main() {
 	}
 	r.Mapper = customTypes
 
+	// Field doc comments become JSON Schema descriptions (editor tooltips), so the
+	// Go source stays the single source of truth for what each field means.
+	if err := r.AddGoComments("github.com/home-operations/chaski", "./internal/config"); err != nil {
+		fmt.Fprintln(os.Stderr, "schema: comments:", err)
+		os.Exit(1)
+	}
+
 	schema := r.Reflect(&config.RouteConfig{})
 
 	// A Target is an externally-tagged union: exactly one of apprise|http. Struct

--- a/config.schema.json
+++ b/config.schema.json
@@ -6,66 +6,84 @@
     "AppriseSink": {
       "properties": {
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "URL is the apprise-go target URL; its scheme selects the provider and\ncarries the credentials (e.g. pover://user@token). Required."
         }
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["url"]
+      "required": ["url"],
+      "description": "AppriseSink is a notification target: an Apprise URL whose scheme selects the provider (pover://, ntfy://, …)."
     },
     "HTTPSink": {
       "properties": {
         "method": {
-          "type": "string"
+          "type": "string",
+          "description": "Method is the HTTP method (default POST)."
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "URL is the endpoint to forward to. Required."
         },
         "headers": {
           "additionalProperties": {
             "type": "string"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Headers are static (or {{ env }}-rendered) request headers."
         },
         "timeout": {
           "type": "string",
+          "description": "Timeout is the per-request deadline (e.g. \"5s\"); default CHASKI_REQUEST_TIMEOUT.",
           "examples": ["10s", "500ms", "1m30s"]
         },
         "retry": {
-          "$ref": "#/$defs/Retry"
+          "$ref": "#/$defs/Retry",
+          "description": "Retry overrides the default CHASKI_RETRY_* policy for this target."
         }
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["url"]
+      "required": ["url"],
+      "description": "HTTPSink is a generic HTTP forward target."
     },
     "Response": {
       "properties": {
         "status": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Status is returned on a successful relay (default 200)."
         },
         "skipStatus": {
-          "type": "integer"
+          "type": "integer",
+          "description": "SkipStatus is returned when the whenExpr gate is false (default 204)."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Response overrides the literal status codes a sender observes."
     },
     "Retry": {
       "properties": {
         "attempts": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Attempts is the max send attempts (\u003e= 1)."
         },
         "backoff": {
           "type": "string",
+          "description": "Backoff is the initial exponential backoff (e.g. \"1s\").",
           "examples": ["10s", "500ms", "1m30s"]
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Retry overrides the global retry defaults for a single target."
     },
     "Route": {
       "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description is optional free-text for humans; it appears in logs, the\n`chaski validate` summary, and ?dryRun=1 plans, and is otherwise ignored."
+        },
         "target": {
           "oneOf": [
             {
@@ -107,39 +125,48 @@
               },
               "type": "array"
             }
-          ]
+          ],
+          "description": "Target is the target name(s) this route fans out to: a single name, a list\nof names, or a list mixing names and {name, whenExpr} objects. Required.\nEvery listed target whose whenExpr matches receives the request (no\nfirst-match-wins); a target's whenExpr defaults to true."
         },
         "whenExpr": {
-          "type": "string"
+          "type": "string",
+          "description": "WhenExpr is the per-route CEL boolean gate deciding whether the request is\nrelayed at all. Empty means always fire. (CEL, unlike the Go-template fields.)"
         },
         "title": {
-          "type": "string"
+          "type": "string",
+          "description": "Title is the notification title (Go template); applies to apprise targets."
         },
         "message": {
-          "type": "string"
+          "type": "string",
+          "description": "Message is the relayed body (Go template). Omit it to forward the inbound\nrequest body verbatim to an http target; an empty or omitted message skips\nan apprise send (a bodyless notification is pointless)."
         },
         "params": {
           "additionalProperties": {
             "type": "string"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Params are Go-template values URL-encoded onto an apprise target's query\n(provider fields like priority/sound). Ignored by http targets."
         },
         "headers": {
           "additionalProperties": {
             "type": "string"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Headers are Go-template values merged onto an http target's request headers\n(the target's own headers win a name clash). Ignored by apprise targets."
         },
         "verify": {
-          "$ref": "#/$defs/Verify"
+          "$ref": "#/$defs/Verify",
+          "description": "Verify optionally requires an inbound signature (HMAC or shared token)."
         },
         "response": {
-          "$ref": "#/$defs/Response"
+          "$ref": "#/$defs/Response",
+          "description": "Response optionally overrides the status a sender sees (relay vs skip)."
         }
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["target"]
+      "required": ["target"],
+      "description": "Route gates an inbound webhook with a CEL expression and renders the fields that are relayed to its target(s)."
     },
     "RouteConfig": {
       "properties": {
@@ -147,23 +174,27 @@
           "additionalProperties": {
             "$ref": "#/$defs/Route"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Routes keyed by name; the name is the inbound URL path segment\n(POST /hooks/\u003cname\u003e) and, when SMTP is enabled, the email localpart."
         },
         "targets": {
           "additionalProperties": {
             "$ref": "#/$defs/Target"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Targets are the named sinks that routes deliver to, keyed by name."
         },
         "templates": {
           "additionalProperties": {
             "type": "string"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Templates are shared Go-template snippets, callable from any route field\nwith {{ template \"name\" . }} or {{ include \"name\" . }} (the latter pipes).\nEach value is a Go template, rendered per request like the route fields."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "RouteConfig is the routes + targets loaded from CHASKI_CONFIG (a single YAML file or a config.d directory of fragments merged additively)."
     },
     "Target": {
       "oneOf": [
@@ -175,35 +206,48 @@
         }
       ],
       "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description is optional free-text for humans; surfaced in the validate\nsummary and otherwise ignored."
+        },
         "apprise": {
-          "$ref": "#/$defs/AppriseSink"
+          "$ref": "#/$defs/AppriseSink",
+          "description": "Apprise sends a notification via an apprise-go URL."
         },
         "http": {
-          "$ref": "#/$defs/HTTPSink"
+          "$ref": "#/$defs/HTTPSink",
+          "description": "HTTP forwards to a generic HTTP endpoint."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Target is a config-defined sink."
     },
     "Verify": {
       "properties": {
         "provider": {
-          "type": "string"
+          "type": "string",
+          "description": "Provider is a named preset that fills the other fields (e.g. \"github\").\nUse it OR Type, not both."
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "Type is the generic mode (\"hmac\" | \"token\") when no preset is used."
         },
         "header": {
-          "type": "string"
+          "type": "string",
+          "description": "Header is the request header carrying the signature/token."
         },
         "algo": {
-          "type": "string"
+          "type": "string",
+          "description": "Algo is the HMAC hash (e.g. \"sha256\"); hmac mode only."
         },
         "encoding": {
-          "type": "string"
+          "type": "string",
+          "description": "Encoding is the signature encoding (\"hex\" | \"base64\"); hmac mode only."
         },
         "prefix": {
-          "type": "string"
+          "type": "string",
+          "description": "Prefix is a literal prefix stripped from the header value (e.g. \"sha256=\")."
         },
         "secret": {
           "oneOf": [
@@ -216,11 +260,13 @@
               },
               "type": "array"
             }
-          ]
+          ],
+          "description": "Secret is one secret or a list (each tried, so secrets rotate cleanly)."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Verify is an optional per-route inbound signature check over the raw body."
     }
   }
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -213,6 +213,22 @@ func TestDuplicateTargetInRouteRejected(t *testing.T) {
 	}
 }
 
+func TestDescriptionRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, "c.yaml"),
+		"targets:\n  a: { description: a sink, apprise: { url: 'pover://u@t/' } }\nroutes:\n  r: { description: a route, target: a, message: m }\n")
+	rc, err := LoadRouteConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadRouteConfig: %v", err)
+	}
+	if got := rc.Routes["r"].Description; got != "a route" {
+		t.Errorf("route description = %q, want %q", got, "a route")
+	}
+	if got := rc.Targets["a"].Description; got != "a sink" {
+		t.Errorf("target description = %q, want %q", got, "a sink")
+	}
+}
+
 func TestSinkValidation(t *testing.T) {
 	tests := map[string]string{
 		"both sinks":     "targets:\n  x: {apprise: {url: 'pover://u@t/'}, http: {url: 'https://h'}}\n",

--- a/internal/config/routes.go
+++ b/internal/config/routes.go
@@ -11,7 +11,10 @@ import (
 // file or a config.d directory of fragments merged additively). It is distinct
 // from Config, which carries the ops/secret settings from the environment.
 type RouteConfig struct {
-	Routes  map[string]*Route  `yaml:"routes"`
+	// Routes keyed by name; the name is the inbound URL path segment
+	// (POST /hooks/<name>) and, when SMTP is enabled, the email localpart.
+	Routes map[string]*Route `yaml:"routes"`
+	// Targets are the named sinks that routes deliver to, keyed by name.
 	Targets map[string]*Target `yaml:"targets"`
 	// Templates are shared Go-template snippets, callable from any route field
 	// with {{ template "name" . }} or {{ include "name" . }} (the latter pipes).
@@ -34,21 +37,28 @@ func (rc *RouteConfig) TemplateSource(name string) string {
 // that are relayed to its target(s). whenExpr is the only CEL field; title,
 // message, and the params/headers values are Go templates evaluated per request.
 type Route struct {
-	// Target is one target name, a list of names, or a list mixing names and
-	// {name, whenExpr} objects to fan out to. Required. A target's whenExpr gates
-	// that single sink, so the route fans out only to the targets whose
-	// expression matches the request. (`jsonschema` tags are inert at runtime —
-	// read only by cmd/schema.)
+	// Description is optional free-text for humans; it appears in logs, the
+	// `chaski validate` summary, and ?dryRun=1 plans, and is otherwise ignored.
+	Description string `yaml:"description"`
+	// Target is the target name(s) this route fans out to: a single name, a list
+	// of names, or a list mixing names and {name, whenExpr} objects. Required.
+	// Every listed target whose whenExpr matches receives the request (no
+	// first-match-wins); a target's whenExpr defaults to true.
 	Target TargetRefs `yaml:"target" jsonschema:"required"`
-	// WhenExpr is the CEL boolean gate (default true when empty).
+	// WhenExpr is the per-route CEL boolean gate deciding whether the request is
+	// relayed at all. Empty means always fire. (CEL, unlike the Go-template fields.)
 	WhenExpr string `yaml:"whenExpr"`
-	// Title and Message are Go templates. Message is a pointer so an omitted
-	// body (verbatim forward for http) is distinguishable from an empty one.
-	Title   string  `yaml:"title"`
+	// Title is the notification title (Go template); applies to apprise targets.
+	Title string `yaml:"title"`
+	// Message is the relayed body (Go template). Omit it to forward the inbound
+	// request body verbatim to an http target; an empty or omitted message skips
+	// an apprise send (a bodyless notification is pointless).
 	Message *string `yaml:"message"`
-	// Params are provider field templates merged into an apprise target's URL
-	// query; Headers are templates merged onto an http target's request.
-	Params  map[string]string `yaml:"params"`
+	// Params are Go-template values URL-encoded onto an apprise target's query
+	// (provider fields like priority/sound). Ignored by http targets.
+	Params map[string]string `yaml:"params"`
+	// Headers are Go-template values merged onto an http target's request headers
+	// (the target's own headers win a name clash). Ignored by apprise targets.
 	Headers map[string]string `yaml:"headers"`
 	// Verify optionally requires an inbound signature (HMAC or shared token).
 	Verify *Verify `yaml:"verify"`
@@ -64,8 +74,13 @@ type Route struct {
 // exactly one of Apprise or HTTP — the variant key is the discriminator, so an
 // invalid sink is unrepresentable.
 type Target struct {
+	// Description is optional free-text for humans; surfaced in the validate
+	// summary and otherwise ignored.
+	Description string `yaml:"description"`
+	// Apprise sends a notification via an apprise-go URL.
 	Apprise *AppriseSink `yaml:"apprise"`
-	HTTP    *HTTPSink    `yaml:"http"`
+	// HTTP forwards to a generic HTTP endpoint.
+	HTTP *HTTPSink `yaml:"http"`
 
 	// Source is the fragment file a target was loaded from; set by the loader.
 	Source string `yaml:"-"`
@@ -87,43 +102,58 @@ func (t *Target) Kind() string {
 // AppriseSink is a notification target: an Apprise URL whose scheme selects the
 // provider (pover://, ntfy://, …). Credentials live here, never in payload.
 type AppriseSink struct {
+	// URL is the apprise-go target URL; its scheme selects the provider and
+	// carries the credentials (e.g. pover://user@token). Required.
 	URL string `yaml:"url" jsonschema:"required"`
 }
 
 // HTTPSink is a generic HTTP forward target.
 type HTTPSink struct {
-	Method  string            `yaml:"method"`
-	URL     string            `yaml:"url" jsonschema:"required"`
+	// Method is the HTTP method (default POST).
+	Method string `yaml:"method"`
+	// URL is the endpoint to forward to. Required.
+	URL string `yaml:"url" jsonschema:"required"`
+	// Headers are static (or {{ env }}-rendered) request headers.
 	Headers map[string]string `yaml:"headers"`
-	Timeout Duration          `yaml:"timeout"`
-	Retry   *Retry            `yaml:"retry"`
+	// Timeout is the per-request deadline (e.g. "5s"); default CHASKI_REQUEST_TIMEOUT.
+	Timeout Duration `yaml:"timeout"`
+	// Retry overrides the default CHASKI_RETRY_* policy for this target.
+	Retry *Retry `yaml:"retry"`
 }
 
 // Retry overrides the global retry defaults for a single target.
 type Retry struct {
-	Attempts int      `yaml:"attempts"`
-	Backoff  Duration `yaml:"backoff"`
+	// Attempts is the max send attempts (>= 1).
+	Attempts int `yaml:"attempts"`
+	// Backoff is the initial exponential backoff (e.g. "1s").
+	Backoff Duration `yaml:"backoff"`
 }
 
 // Verify is an optional per-route inbound signature check over the raw body.
 type Verify struct {
-	// Provider is a preset ("github"); Type selects a generic mode
-	// ("hmac" | "token") when no preset is used.
+	// Provider is a named preset that fills the other fields (e.g. "github").
+	// Use it OR Type, not both.
 	Provider string `yaml:"provider"`
-	Type     string `yaml:"type"`
-	Header   string `yaml:"header"`
-	Algo     string `yaml:"algo"`
+	// Type is the generic mode ("hmac" | "token") when no preset is used.
+	Type string `yaml:"type"`
+	// Header is the request header carrying the signature/token.
+	Header string `yaml:"header"`
+	// Algo is the HMAC hash (e.g. "sha256"); hmac mode only.
+	Algo string `yaml:"algo"`
+	// Encoding is the signature encoding ("hex" | "base64"); hmac mode only.
 	Encoding string `yaml:"encoding"`
-	Prefix   string `yaml:"prefix"`
+	// Prefix is a literal prefix stripped from the header value (e.g. "sha256=").
+	Prefix string `yaml:"prefix"`
 	// Secret is one secret or a list (each tried, so secrets rotate cleanly).
 	Secret StringList `yaml:"secret"`
 }
 
-// Response overrides the literal status codes a sender observes: Status on a
-// successful relay (default 200), SkipStatus on a whenExpr-false skip (default
-// 204). The 4xx/5xx error codes are not overridable.
+// Response overrides the literal status codes a sender observes. The 4xx/5xx
+// error codes are not overridable.
 type Response struct {
-	Status     int `yaml:"status"`
+	// Status is returned on a successful relay (default 200).
+	Status int `yaml:"status"`
+	// SkipStatus is returned when the whenExpr gate is false (default 204).
 	SkipStatus int `yaml:"skipStatus"`
 }
 


### PR DESCRIPTION
First of two PRs from the config-schema UX review (the additive, non-breaking half). Grounded in how Home Assistant / GitHub Actions / Argo separate a human label from the machine key.

## Changes

**`description:` on routes and targets** — optional free-text for humans. The route map key stays the identity (URL path `/hooks/<name>` + SMTP localpart); this just gives prose a home. Surfaces in the `chaski validate` summary:
```
  route alerts                   (chaski.yaml) → [po]
      firing alerts
```

**Self-documenting schema** — wired invopop `AddGoComments`, so every config field's Go doc comment becomes its JSON Schema `description` (editor tooltips). Gave each decoded field its own user-facing comment, which let me bake in the behaviors the review flagged as load-bearing-but-invisible:
- `message`: omit → forward the inbound body to http / skip an apprise send; empty also skips apprise.
- `params` is apprise-only, `headers` is http-only (each no-ops on the other kind).
- `response` 4xx/5xx are not overridable.

**README env-var table** — added the **8 undocumented** `CHASKI_*` vars (`LOG_LEVEL`, `LOG_FORMAT`, `METRICS_ENABLED`, `DISABLE_REQUEST_LOGS`, `SHUTDOWN_TIMEOUT`, `SMTP_HOSTNAME`, `SMTP_MAX_MESSAGE_BYTES`, `SMTP_MAX_RECIPIENTS`) and noted that a target's `timeout`/`retry` override `CHASKI_REQUEST_TIMEOUT`/`CHASKI_RETRY_*`.

Regenerated `config.schema.json` (now carries descriptions). No field renames, no breaking changes. The breaking `verify`-union restructure is a separate PR. `go test -race ./...`, lint (0), `generate-check`, helm all green.
