### PR TITLE
feat(config)!: model verify as a github|hmac|token union

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,39 @@ server serves. An `include` name must be a string literal (`{{ include "label"
 . }}`), like the `{{ template }}` action. `whenExpr` is CEL, so snippets don't
 apply there — only to the Go-template fields.
 
+## Verifying senders
+
+A route may require an inbound signature over the raw body. `verify` is a
+discriminated union — exactly one of `github`, `hmac`, or `token`:
+
+```yaml
+routes:
+  github:
+    target: relay
+    verify:
+      github:
+        secret: '{{ env "GH_WEBHOOK_SECRET" }}' # HMAC-SHA256 in X-Hub-Signature-256
+  gitlab:
+    target: relay
+    verify:
+      token: # shared secret, presented verbatim in a header
+        header: X-Gitlab-Token
+        secret: '{{ env "GL_WEBHOOK_TOKEN" }}'
+  custom:
+    target: relay
+    verify:
+      hmac: # generic HMAC
+        header: X-Signature
+        algo: sha256 # sha256 (default) | sha512
+        encoding: hex # hex (default) | base64
+        prefix: "sha256=" # stripped before decoding
+        secret: '{{ env "HMAC_SECRET" }}'
+```
+
+`secret` accepts one value or a list (each is tried, so secrets rotate without
+downtime). A failed or missing signature is a quiet `401`. Comparisons are
+constant-time; secrets are never exposed to `whenExpr` or templates.
+
 ## SMTP ingestion
 
 chaski can also accept notifications over **SMTP**, so devices that can only send

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -49,6 +49,15 @@ func main() {
 		}
 	}
 
+	// Verify is likewise an externally-tagged union: exactly one of github|hmac|token.
+	if verify, ok := schema.Definitions["Verify"]; ok {
+		verify.OneOf = []*jsonschema.Schema{
+			{Required: []string{"github"}},
+			{Required: []string{"hmac"}},
+			{Required: []string{"token"}},
+		}
+	}
+
 	data, err := json.MarshalIndent(schema, "", "  ")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "schema: marshal:", err)

--- a/config.schema.json
+++ b/config.schema.json
@@ -15,6 +15,66 @@
       "required": ["url"],
       "description": "AppriseSink is a notification target: an Apprise URL whose scheme selects the provider (pover://, ntfy://, …)."
     },
+    "GitHubVerify": {
+      "properties": {
+        "secret": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Secret is one secret or a list (each tried, so secrets rotate cleanly)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": ["secret"],
+      "description": "GitHubVerify is the GitHub webhook preset; only the secret is configurable."
+    },
+    "HMACVerify": {
+      "properties": {
+        "header": {
+          "type": "string",
+          "description": "Header carries the signature. Required."
+        },
+        "algo": {
+          "type": "string",
+          "description": "Algo is the hash: \"sha256\" (default) or \"sha512\"."
+        },
+        "encoding": {
+          "type": "string",
+          "description": "Encoding of the signature: \"hex\" (default) or \"base64\"."
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Prefix is stripped from the header value before decoding (e.g. \"sha256=\")."
+        },
+        "secret": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Secret is one secret or a list (each tried, so secrets rotate cleanly)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": ["header", "secret"],
+      "description": "HMACVerify verifies an HMAC of the raw body carried in a request header."
+    },
     "HTTPSink": {
       "properties": {
         "method": {
@@ -223,31 +283,11 @@
       "type": "object",
       "description": "Target is a config-defined sink."
     },
-    "Verify": {
+    "TokenVerify": {
       "properties": {
-        "provider": {
-          "type": "string",
-          "description": "Provider is a named preset that fills the other fields (e.g. \"github\").\nUse it OR Type, not both."
-        },
-        "type": {
-          "type": "string",
-          "description": "Type is the generic mode (\"hmac\" | \"token\") when no preset is used."
-        },
         "header": {
           "type": "string",
-          "description": "Header is the request header carrying the signature/token."
-        },
-        "algo": {
-          "type": "string",
-          "description": "Algo is the HMAC hash (e.g. \"sha256\"); hmac mode only."
-        },
-        "encoding": {
-          "type": "string",
-          "description": "Encoding is the signature encoding (\"hex\" | \"base64\"); hmac mode only."
-        },
-        "prefix": {
-          "type": "string",
-          "description": "Prefix is a literal prefix stripped from the header value (e.g. \"sha256=\")."
+          "description": "Header carries the token. Required."
         },
         "secret": {
           "oneOf": [
@@ -262,6 +302,37 @@
             }
           ],
           "description": "Secret is one secret or a list (each tried, so secrets rotate cleanly)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": ["header", "secret"],
+      "description": "TokenVerify requires a shared secret presented verbatim in a request header."
+    },
+    "Verify": {
+      "oneOf": [
+        {
+          "required": ["github"]
+        },
+        {
+          "required": ["hmac"]
+        },
+        {
+          "required": ["token"]
+        }
+      ],
+      "properties": {
+        "github": {
+          "$ref": "#/$defs/GitHubVerify",
+          "description": "GitHub verifies a GitHub webhook: HMAC-SHA256 of the body, hex-encoded in\nthe X-Hub-Signature-256 header with a \"sha256=\" prefix."
+        },
+        "hmac": {
+          "$ref": "#/$defs/HMACVerify",
+          "description": "HMAC verifies a generic HMAC signature carried in a request header."
+        },
+        "token": {
+          "$ref": "#/$defs/TokenVerify",
+          "description": "Token requires a shared secret presented verbatim in a request header."
         }
       },
       "additionalProperties": false,

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -229,6 +229,27 @@ func TestDescriptionRoundTrips(t *testing.T) {
 	}
 }
 
+func TestVerifyUnionDecode(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "c.yaml")
+
+	write(t, file, "targets:\n  t: {apprise: {url: 'pover://u@t/'}}\nroutes:\n  r:\n    target: t\n    message: m\n    verify:\n      github:\n        secret: s\n")
+	rc, err := LoadRouteConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadRouteConfig: %v", err)
+	}
+	if v := rc.Routes["r"].Verify; v == nil || v.GitHub == nil || v.VerifyKind() != "github" {
+		t.Fatalf("verify = %+v, want a github variant", rc.Routes["r"].Verify)
+	}
+
+	// The old flat shape (provider/type/secret under verify) is rejected by strict
+	// decode now that verify is a github|hmac|token union.
+	write(t, file, "targets:\n  t: {apprise: {url: 'pover://u@t/'}}\nroutes:\n  r:\n    target: t\n    message: m\n    verify:\n      provider: github\n      secret: s\n")
+	if _, err := LoadRouteConfig(dir); err == nil {
+		t.Error("old flat verify shape (provider/secret) should be rejected")
+	}
+}
+
 func TestSinkValidation(t *testing.T) {
 	tests := map[string]string{
 		"both sinks":     "targets:\n  x: {apprise: {url: 'pover://u@t/'}, http: {url: 'https://h'}}\n",

--- a/internal/config/routes.go
+++ b/internal/config/routes.go
@@ -129,23 +129,75 @@ type Retry struct {
 	Backoff Duration `yaml:"backoff"`
 }
 
-// Verify is an optional per-route inbound signature check over the raw body.
+// Verify is an optional per-route inbound signature check over the raw body. It
+// is an externally-tagged union (like Target): exactly one of github, hmac, or
+// token — the variant key is the discriminator.
 type Verify struct {
-	// Provider is a named preset that fills the other fields (e.g. "github").
-	// Use it OR Type, not both.
-	Provider string `yaml:"provider"`
-	// Type is the generic mode ("hmac" | "token") when no preset is used.
-	Type string `yaml:"type"`
-	// Header is the request header carrying the signature/token.
-	Header string `yaml:"header"`
-	// Algo is the HMAC hash (e.g. "sha256"); hmac mode only.
+	// GitHub verifies a GitHub webhook: HMAC-SHA256 of the body, hex-encoded in
+	// the X-Hub-Signature-256 header with a "sha256=" prefix.
+	GitHub *GitHubVerify `yaml:"github"`
+	// HMAC verifies a generic HMAC signature carried in a request header.
+	HMAC *HMACVerify `yaml:"hmac"`
+	// Token requires a shared secret presented verbatim in a request header.
+	Token *TokenVerify `yaml:"token"`
+}
+
+// VerifyKind returns the configured variant ("github"|"hmac"|"token"), or "" when
+// zero or more than one is set (caught by verify.Compile).
+func (v *Verify) VerifyKind() string {
+	switch {
+	case v.GitHub != nil && v.HMAC == nil && v.Token == nil:
+		return "github"
+	case v.HMAC != nil && v.GitHub == nil && v.Token == nil:
+		return "hmac"
+	case v.Token != nil && v.GitHub == nil && v.HMAC == nil:
+		return "token"
+	default:
+		return ""
+	}
+}
+
+// Secrets returns the configured variant's secret list (or nil), for in-place
+// {{ env }}-rendering by the loader. Mutating the returned slice's elements
+// updates the variant.
+func (v *Verify) Secrets() StringList {
+	switch {
+	case v.GitHub != nil:
+		return v.GitHub.Secret
+	case v.HMAC != nil:
+		return v.HMAC.Secret
+	case v.Token != nil:
+		return v.Token.Secret
+	}
+	return nil
+}
+
+// GitHubVerify is the GitHub webhook preset; only the secret is configurable.
+type GitHubVerify struct {
+	// Secret is one secret or a list (each tried, so secrets rotate cleanly).
+	Secret StringList `yaml:"secret" jsonschema:"required"`
+}
+
+// HMACVerify verifies an HMAC of the raw body carried in a request header.
+type HMACVerify struct {
+	// Header carries the signature. Required.
+	Header string `yaml:"header" jsonschema:"required"`
+	// Algo is the hash: "sha256" (default) or "sha512".
 	Algo string `yaml:"algo"`
-	// Encoding is the signature encoding ("hex" | "base64"); hmac mode only.
+	// Encoding of the signature: "hex" (default) or "base64".
 	Encoding string `yaml:"encoding"`
-	// Prefix is a literal prefix stripped from the header value (e.g. "sha256=").
+	// Prefix is stripped from the header value before decoding (e.g. "sha256=").
 	Prefix string `yaml:"prefix"`
 	// Secret is one secret or a list (each tried, so secrets rotate cleanly).
-	Secret StringList `yaml:"secret"`
+	Secret StringList `yaml:"secret" jsonschema:"required"`
+}
+
+// TokenVerify requires a shared secret presented verbatim in a request header.
+type TokenVerify struct {
+	// Header carries the token. Required.
+	Header string `yaml:"header" jsonschema:"required"`
+	// Secret is one secret or a list (each tried, so secrets rotate cleanly).
+	Secret StringList `yaml:"secret" jsonschema:"required"`
 }
 
 // Response overrides the literal status codes a sender observes. The 4xx/5xx

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -136,12 +136,13 @@ func renderEnv(rc *RouteConfig) error {
 		if r.Verify == nil {
 			continue
 		}
-		for i, secret := range r.Verify.Secret {
+		secrets := r.Verify.Secrets()
+		for i, secret := range secrets {
 			v, err := render(secret, fmt.Sprintf("route %q verify secret", name))
 			if err != nil {
 				return err
 			}
-			r.Verify.Secret[i] = v
+			secrets[i] = v
 		}
 	}
 	return nil

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -31,8 +31,6 @@ const (
 )
 
 const (
-	typeHMAC   = "hmac"
-	typeToken  = "token"
 	encHex     = "hex"
 	encBase64  = "base64"
 	algoSHA256 = "sha256"
@@ -50,61 +48,79 @@ type Verifier struct {
 }
 
 // Compile resolves a config.Verify into a runnable Verifier, failing fast on a
-// malformed block (unknown provider/type, missing header, unsupported
+// malformed block (no variant or more than one, missing header, unsupported
 // algo/encoding, no secret). A nil block yields a nil Verifier.
 func Compile(v *config.Verify) (*Verifier, error) {
 	if v == nil {
 		return nil, nil
 	}
-
-	typ, header, algo, encoding, prefix := v.Type, v.Header, v.Algo, v.Encoding, v.Prefix
-	if v.Provider != "" {
-		switch strings.ToLower(v.Provider) {
-		case "github":
-			// X-Hub-Signature-256: sha256=<hex(hmac-sha256(body))>.
-			typ, header, algo, encoding, prefix = typeHMAC, "X-Hub-Signature-256", algoSHA256, encHex, "sha256="
-		default:
-			return nil, fmt.Errorf("verify: unknown provider %q", v.Provider)
-		}
+	switch {
+	case v.GitHub != nil && v.HMAC == nil && v.Token == nil:
+		// X-Hub-Signature-256: sha256=<hex(hmac-sha256(body))>.
+		return compileHMAC("X-Hub-Signature-256", algoSHA256, encHex, "sha256=", v.GitHub.Secret)
+	case v.HMAC != nil && v.GitHub == nil && v.Token == nil:
+		return compileHMAC(v.HMAC.Header, v.HMAC.Algo, v.HMAC.Encoding, v.HMAC.Prefix, v.HMAC.Secret)
+	case v.Token != nil && v.GitHub == nil && v.HMAC == nil:
+		return compileToken(v.Token.Header, v.Token.Secret)
+	default:
+		return nil, errors.New("verify: set exactly one of github, hmac, or token")
 	}
+}
 
-	if len(v.Secret) == 0 {
+// compileHMAC builds an HMAC verifier; encoding defaults to hex, algo to sha256.
+func compileHMAC(header, algo, encoding, prefix string, secret config.StringList) (*Verifier, error) {
+	if header == "" {
+		return nil, errors.New("verify: hmac requires a header")
+	}
+	secrets, err := secretBytes(secret)
+	if err != nil {
+		return nil, err
+	}
+	if encoding == "" {
+		encoding = encHex
+	}
+	if encoding != encHex && encoding != encBase64 {
+		return nil, fmt.Errorf("verify: unsupported encoding %q (want hex or base64)", encoding)
+	}
+	if algo == "" {
+		algo = algoSHA256
+	}
+	nh, err := hashFor(algo)
+	if err != nil {
+		return nil, err
+	}
+	return &Verifier{mode: modeHMAC, header: header, prefix: prefix, encoding: encoding, newHash: nh, secrets: secrets}, nil
+}
+
+// compileToken builds a shared-token verifier.
+func compileToken(header string, secret config.StringList) (*Verifier, error) {
+	if header == "" {
+		return nil, errors.New("verify: token requires a header")
+	}
+	secrets, err := secretBytes(secret)
+	if err != nil {
+		return nil, err
+	}
+	return &Verifier{mode: modeToken, header: header, secrets: secrets}, nil
+}
+
+// secretBytes captures the configured secrets, requiring at least one and
+// rejecting any empty/whitespace-only value. An empty secret is a fail-open: it
+// builds an empty HMAC key (forgeable by anyone) or an empty token, and the
+// strict env funcmap only catches an *unset* var, not one set to "". Secrets are
+// stored verbatim (no trimming) — only the emptiness check trims.
+func secretBytes(secret config.StringList) ([][]byte, error) {
+	if len(secret) == 0 {
 		return nil, errors.New("verify: at least one secret is required")
 	}
-	secrets := make([][]byte, len(v.Secret))
-	for i, s := range v.Secret {
+	secrets := make([][]byte, len(secret))
+	for i, s := range secret {
+		if strings.TrimSpace(s) == "" {
+			return nil, errors.New("verify: a secret must not be empty")
+		}
 		secrets[i] = []byte(s)
 	}
-	vf := &Verifier{header: header, prefix: prefix, secrets: secrets}
-
-	switch strings.ToLower(typ) {
-	case typeHMAC:
-		if header == "" {
-			return nil, errors.New("verify: hmac requires a header")
-		}
-		if encoding == "" {
-			encoding = encHex
-		}
-		if encoding != encHex && encoding != encBase64 {
-			return nil, fmt.Errorf("verify: unsupported encoding %q (want hex or base64)", encoding)
-		}
-		if algo == "" {
-			algo = algoSHA256
-		}
-		nh, err := hashFor(algo)
-		if err != nil {
-			return nil, err
-		}
-		vf.mode, vf.encoding, vf.newHash = modeHMAC, encoding, nh
-	case typeToken:
-		if header == "" {
-			return nil, errors.New("verify: token requires a header")
-		}
-		vf.mode = modeToken
-	default:
-		return nil, fmt.Errorf("verify: type must be hmac or token (got %q)", typ)
-	}
-	return vf, nil
+	return secrets, nil
 }
 
 // Verify reports whether the request's header satisfies the configured check

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -40,7 +40,7 @@ func hdr(k, v string) http.Header {
 
 func TestGitHubPreset(t *testing.T) {
 	body := `{"action":"opened"}`
-	vf := mustCompile(t, &config.Verify{Provider: "github", Secret: config.StringList{"s3cr3t"}})
+	vf := mustCompile(t, &config.Verify{GitHub: &config.GitHubVerify{Secret: config.StringList{"s3cr3t"}}})
 
 	good := hdr("X-Hub-Signature-256", "sha256="+hmacHex("s3cr3t", body))
 	if !vf.Verify(good, []byte(body)) {
@@ -59,10 +59,10 @@ func TestGitHubPreset(t *testing.T) {
 
 func TestGenericHMACBase64(t *testing.T) {
 	body := "payload"
-	vf := mustCompile(t, &config.Verify{
-		Type: "hmac", Header: "X-Sig", Algo: "sha256", Encoding: "base64",
+	vf := mustCompile(t, &config.Verify{HMAC: &config.HMACVerify{
+		Header: "X-Sig", Algo: "sha256", Encoding: "base64",
 		Secret: config.StringList{"key"},
-	})
+	}})
 	if !vf.Verify(hdr("X-Sig", hmacB64("key", body)), []byte(body)) {
 		t.Error("valid base64 HMAC should verify")
 	}
@@ -72,7 +72,7 @@ func TestGenericHMACBase64(t *testing.T) {
 }
 
 func TestToken(t *testing.T) {
-	vf := mustCompile(t, &config.Verify{Type: "token", Header: "X-Gitlab-Token", Secret: config.StringList{"tok"}})
+	vf := mustCompile(t, &config.Verify{Token: &config.TokenVerify{Header: "X-Gitlab-Token", Secret: config.StringList{"tok"}}})
 	if !vf.Verify(hdr("X-Gitlab-Token", "tok"), []byte("anything")) {
 		t.Error("matching token should verify")
 	}
@@ -83,7 +83,7 @@ func TestToken(t *testing.T) {
 
 func TestSecretRotation(t *testing.T) {
 	body := "b"
-	vf := mustCompile(t, &config.Verify{Provider: "github", Secret: config.StringList{"old", "new"}})
+	vf := mustCompile(t, &config.Verify{GitHub: &config.GitHubVerify{Secret: config.StringList{"old", "new"}}})
 	// Signed with the second (rotated-in) secret.
 	if !vf.Verify(hdr("X-Hub-Signature-256", "sha256="+hmacHex("new", body)), []byte(body)) {
 		t.Error("a signature from any listed secret should verify")
@@ -105,13 +105,15 @@ func TestNilVerifyAcceptsAll(t *testing.T) {
 
 func TestCompileErrors(t *testing.T) {
 	tests := map[string]*config.Verify{
-		"unknown provider": {Provider: "bitbucket", Secret: config.StringList{"s"}},
-		"unknown type":     {Type: "magic", Header: "X", Secret: config.StringList{"s"}},
-		"no secret":        {Type: "token", Header: "X"},
-		"hmac no header":   {Type: "hmac", Secret: config.StringList{"s"}},
-		"token no header":  {Type: "token", Secret: config.StringList{"s"}},
-		"bad encoding":     {Type: "hmac", Header: "X", Encoding: "rot13", Secret: config.StringList{"s"}},
-		"bad algo":         {Type: "hmac", Header: "X", Algo: "md5", Secret: config.StringList{"s"}},
+		"no variant":        {},
+		"multiple variants": {GitHub: &config.GitHubVerify{Secret: config.StringList{"s"}}, Token: &config.TokenVerify{Header: "X", Secret: config.StringList{"s"}}},
+		"no secret":         {Token: &config.TokenVerify{Header: "X"}},
+		"hmac no header":    {HMAC: &config.HMACVerify{Secret: config.StringList{"s"}}},
+		"token no header":   {Token: &config.TokenVerify{Secret: config.StringList{"s"}}},
+		"bad encoding":      {HMAC: &config.HMACVerify{Header: "X", Encoding: "rot13", Secret: config.StringList{"s"}}},
+		"bad algo":          {HMAC: &config.HMACVerify{Header: "X", Algo: "md5", Secret: config.StringList{"s"}}},
+		"empty secret":      {Token: &config.TokenVerify{Header: "X", Secret: config.StringList{""}}},
+		"whitespace secret": {GitHub: &config.GitHubVerify{Secret: config.StringList{"  "}}},
 	}
 	for name, v := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
**Breaking change.** Second of the two config-schema-review PRs (the one breaking restructure with a real modeling argument).

`verify` was the **only** config object that didn't use chaski's own externally-tagged-union idiom (cf. `target`'s `apprise`/`http`). Its flat `provider`/`type` either-or let the schema accept both, neither, or contradictory combinations — only the boot check caught it. This makes the variant a kind-as-key discriminator, so an invalid shape is unrepresentable and `algo`/`encoding` live only on the variant that uses them.

```yaml
verify: { github: { secret } }                               # preset
verify: { hmac:   { header, algo, encoding, prefix, secret } }
verify: { token:  { header, secret } }
```

## Behavior — identical, just reshaped
`verify.Compile` now dispatches on the variant:
- `github` → HMAC-SHA256, `X-Hub-Signature-256`, hex, `sha256=` prefix (unchanged preset).
- `hmac` → defaults `sha256`/`hex`; header required.
- `token` → shared secret compared against a header.
- `secret` is one value or a list (rotation); required for all. Constant-time; never exposed to `whenExpr`/templates.

Schema gets a `oneOf` over the three variants (mirroring `Target`); README gains a "Verifying senders" section.

## BREAKING CHANGE
The flat shape is gone — the old keys now fail strict decode at boot / `chaski validate`:
| Old | New |
|---|---|
| `verify: { provider: github, secret: … }` | `verify: { github: { secret: … } }` |
| `verify: { type: hmac, header: …, … }` | `verify: { hmac: { header: …, … } }` |
| `verify: { type: token, header: …, … }` | `verify: { token: { header: …, … } }` |

Tests: variant decode + old-shape-rejected, and the full verify suite reshaped (github/hmac/token, rotation, none/multiple-variant errors). `go test -race ./...`, lint (0), `generate-check`, helm (19/19) all green.

> Note: overlaps #22 on `internal/config/routes.go` — whichever merges second I'll rebase (trivial; PR B rewrites the `Verify` struct that #22 only re-commented).
