### PR TITLE
feat(server): log monitoring-endpoint requests at debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,9 @@ from the environment:
 A JSON Schema for the route config is published at
 [`config.schema.json`](config.schema.json) — point your editor's YAML language
 server at it for completion and validation. The metrics port serves
-`GET /metrics` (Prometheus) and `GET /healthz`.
+`GET /metrics` (Prometheus) and `GET /healthz`; requests to these
+monitoring endpoints are logged at `debug`, so scrapes and probes don't fill the
+`info` access log (set `CHASKI_LOG_LEVEL=debug` to see them).
 
 Key metrics:
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -61,7 +61,8 @@ func recoverer(log *slog.Logger) func(http.Handler) http.Handler {
 	}
 }
 
-// observe records Prometheus metrics and emits the per-request access log.
+// observe records Prometheus metrics and emits the per-request access log. It
+// wraps the public webhook listener.
 func (s *Server) observe(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -73,15 +74,45 @@ func (s *Server) observe(next http.Handler) http.Handler {
 		method := methodLabel(r.Method)
 		httpRequests.WithLabelValues(method, statusClass(rec.status)).Inc()
 		httpDuration.WithLabelValues(method).Observe(duration.Seconds())
-
-		if !s.cfg.DisableRequestLogs {
-			s.log.Info("request",
-				"method", r.Method,
-				"path", r.URL.Path,
-				"status", rec.status,
-				"remote", r.RemoteAddr,
-				"duration", duration.String(),
-			)
-		}
+		s.logRequest(r, rec.status, duration)
 	})
+}
+
+// accessLog emits the per-request access log WITHOUT recording request metrics.
+// It wraps the monitoring listener, so /metrics scrapes and /healthz probes are
+// logged (at debug — see logRequest) without inflating the request counters.
+func (s *Server) accessLog(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+		s.logRequest(r, rec.status, time.Since(start))
+	})
+}
+
+// monitoringPaths are the scrape/probe endpoints whose access log is noise at
+// the scrape/probe cadence, so it is emitted at Debug — visible only under
+// CHASKI_LOG_LEVEL=debug — rather than at Info with real traffic.
+var monitoringPaths = map[string]struct{}{
+	"/metrics": {}, "/healthz": {}, "/readyz": {},
+}
+
+// logRequest emits the access log for one request at the path-appropriate level
+// (Debug for the monitoring endpoints, Info otherwise), unless request logs are
+// disabled entirely.
+func (s *Server) logRequest(r *http.Request, status int, d time.Duration) {
+	if s.cfg.DisableRequestLogs {
+		return
+	}
+	level := slog.LevelInfo
+	if _, ok := monitoringPaths[r.URL.Path]; ok {
+		level = slog.LevelDebug
+	}
+	s.log.Log(r.Context(), level, "request",
+		"method", r.Method,
+		"path", r.URL.Path,
+		"status", status,
+		"remote", r.RemoteAddr,
+		"duration", d.String(),
+	)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -59,7 +59,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 	var metricsSrv *http.Server
 	if s.cfg.MetricsEnabled {
-		metricsSrv = newHTTPServer(fmt.Sprintf(":%d", s.cfg.MetricsPort), metricsHandler())
+		metricsSrv = newHTTPServer(fmt.Sprintf(":%d", s.cfg.MetricsPort), s.accessLog(metricsHandler()))
 		g.Go(func() error { return serve(metricsSrv, "metrics", s.log) })
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -93,6 +93,46 @@ func do(srv *Server, method, target, body string, headers map[string]string) *ht
 
 const jsonCT = "application/json"
 
+// capHandler records the level of each emitted log record.
+type capHandler struct{ levels *[]slog.Level }
+
+func (h capHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h capHandler) WithAttrs([]slog.Attr) slog.Handler       { return h }
+func (h capHandler) WithGroup(string) slog.Handler            { return h }
+func (h capHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.levels = append(*h.levels, r.Level)
+	return nil
+}
+
+// TestRequestLogLevels: monitoring endpoints log at Debug, real traffic at Info,
+// and DisableRequestLogs silences everything.
+func TestRequestLogLevels(t *testing.T) {
+	cases := map[string]slog.Level{
+		"/healthz": slog.LevelDebug,
+		"/readyz":  slog.LevelDebug,
+		"/metrics": slog.LevelDebug,
+		"/hooks/x": slog.LevelInfo,
+		"/":        slog.LevelInfo,
+	}
+	for path, want := range cases {
+		var levels []slog.Level
+		srv := &Server{cfg: &config.Config{}, log: slog.New(capHandler{&levels})}
+		srv.accessLog(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})).
+			ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, path, nil))
+		if len(levels) != 1 || levels[0] != want {
+			t.Errorf("path %q: levels=%v, want [%v]", path, levels, want)
+		}
+	}
+
+	var levels []slog.Level
+	srv := &Server{cfg: &config.Config{DisableRequestLogs: true}, log: slog.New(capHandler{&levels})}
+	srv.accessLog(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})).
+		ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if len(levels) != 0 {
+		t.Errorf("DisableRequestLogs: emitted %d logs, want 0", len(levels))
+	}
+}
+
 func TestHealthz(t *testing.T) {
 	rec := httptest.NewRecorder()
 	metricsHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))


### PR DESCRIPTION
Monitoring-endpoint requests (`/metrics` scrapes, `/healthz` + `/readyz` probes) now log at **`debug`** instead of cluttering the `info` access log.

## Why
The access log emitted every request at `info`, and the monitoring listener wasn't logged at all. Prometheus scrapes (~every 15–30s) and k8s liveness/readiness probes (every few seconds) are pure noise at `info`, but useful when you're actually debugging the probe path.

## What
- `logRequest` picks the level by path: **`debug`** for `/metrics`, `/healthz`, `/readyz`; **`info`** for real traffic.
- The monitoring listener is wrapped with a **log-only** middleware (`accessLog`) so its requests are logged at debug — visible under `CHASKI_LOG_LEVEL=debug`, silent at `info` — **without** inflating the `chaski_http_requests_total` / `_duration` counters with self-scrape traffic (those stay on the webhook listener only).
- `CHASKI_DISABLE_REQUEST_LOGS` still silences everything.

Net: the default `info` log shows only real webhook traffic; flip to `debug` to see scrapes and probes. Test asserts the level mapping (`/healthz|/readyz|/metrics`→debug, `/hooks/x`,`/`→info) and that `DisableRequestLogs` emits nothing. `go test -race ./...`, lint (0), `generate-check`, all green.
