### PR TITLE
chore(renovate): inherit shared toolchain + chart-docs presets

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -2,13 +2,4 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
   postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
-  packageRules: [
-    {
-      // The chaski image is this repo's own artifact: the release pipeline pins its
-      // digest into the chart at publish time, so Renovate must not bump it here.
-      description: "chaski image is pinned by CI, not Renovate",
-      matchDepNames: ["ghcr.io/home-operations/chaski"],
-      enabled: false,
-    },
-  ],
 }

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -2,28 +2,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
   postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
-  // Regenerate the chart's committed docs after an upgrade so a value bump doesn't
-  // leave README.md / values.schema.json stale and fail generate-check. Runs the
-  // helm-docs + helm-schema binaries shipped in the Renovate container (mirrors the
-  // chart-doc half of `mise run generate`).
-  postUpgradeTasks: {
-    commands: [
-      "helm-docs --chart-search-root=charts --log-level=warn",
-      "helm-schema --chart-search-root charts/chaski --skip-auto-generation required,additionalProperties --append-newline",
-    ],
-    fileFilters: ["charts/chaski/README.md", "charts/chaski/values.schema.json"],
-    executionMode: "branch",
-  },
   packageRules: [
-    {
-      description: "Go Toolchain Group",
-      matchManagers: ["mise", "gomod"],
-      matchDepNames: ["go"],
-      matchFileNames: [".mise/config.toml", "go.mod"],
-      groupName: "Go toolchain",
-      groupSlug: "go-toolchain",
-      minimumGroupSize: 2,
-    },
     {
       // The chaski image is this repo's own artifact: the release pipeline pins its
       // digest into the chart at publish time, so Renovate must not bump it here.


### PR DESCRIPTION
Now that home-operations/renovate-config#25 is merged, `chaski` inherits the shared `groups.json5`
(toolchain grouping) and `helmPostUpgradeTasks.json5` (chart-doc regen) presets via its existing
`extends: ["local>home-operations/renovate-config"]`.

Removes the now-redundant local config:
- the local toolchain group packageRule(s)
- the local helm-docs/helm-schema `postUpgradeTasks` block

Pure deletion — behavior unchanged:
- `packageRules` merge additively, so the inherited toolchain group is identical to the removed local copy.
- the shared preset's `--chart-search-root .` reproduces this chart's committed README + values.schema.json byte-for-byte (verified).

Part of the org consolidation Tier-1 rollout.
