### PR TITLE
feat(gate): enable CEL network + base64 extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ exception is the per-route gate `whenExpr`, a
 [CEL](https://github.com/google/cel-go) boolean. Both see the same variables:
 `payload`, `headers`, `query`, `method`, `route`, `now`.
 
+Beyond core CEL, `whenExpr` has the
+[strings](https://github.com/google/cel-go/tree/master/ext#strings) and
+[network](https://github.com/google/cel-go/tree/master/ext#network) extensions
+(`ip()`, `cidr()`, `isIP()`, `isCIDR()`, containment — e.g.
+`cidr("10.0.0.0/8").containsIP(payload.client_ip)`), `base64.encode`/`base64.decode`,
+`toJSON(v)` (canonical JSON of any value), and `truncate(s, n)` (rune-safe prefix).
+
 A richer **apprise** route — a severity-driven title, a bullet per alert, and a
 priority/sound chosen from the payload:
 

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -123,6 +123,10 @@ func newEnv() (*cel.Env, error) {
 		cel.Variable("route", cel.StringType),
 		cel.Variable("now", cel.TimestampType),
 		ext.Strings(),
+		// Kubernetes-style ip()/cidr()/isIP()/isCIDR() + containment checks.
+		ext.Network(),
+		// Version 0 = base64.encode/decode only; JSON stays on toJSON below.
+		ext.Encoders(ext.EncodersVersion(0)),
 		toJSONFunc(),
 		truncateFunc(),
 	)

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -18,10 +18,11 @@ func mustCompile(t *testing.T, expr string) *Gate {
 func sampleInput() Input {
 	return Input{
 		Payload: map[string]any{
-			"status": "firing",
-			"count":  float64(10), // JSON numbers decode as float64 (CEL double)
-			"msg":    "abcdef",
-			"name":   "world",
+			"status":    "firing",
+			"count":     float64(10), // JSON numbers decode as float64 (CEL double)
+			"msg":       "abcdef",
+			"name":      "world",
+			"client_ip": "10.1.2.3",
 		},
 		Headers: map[string]string{"x-source": "ci"},
 		Query:   map[string]string{"dry": "1"},
@@ -91,6 +92,40 @@ func TestHelpers(t *testing.T) {
 	}
 	if !eval(t, `truncate(payload.msg, 100) == "abcdef"`) {
 		t.Error(`truncate beyond length should return the whole string`)
+	}
+}
+
+func TestNetworkExtension(t *testing.T) {
+	tests := map[string]bool{
+		`isIP(string(payload.client_ip))`:                        true,
+		`isIP("not-an-ip")`:                                      false,
+		`cidr("10.0.0.0/8").containsIP(ip(payload.client_ip))`:   true,
+		`cidr("10.0.0.0/8").containsIP(payload.client_ip)`:       true, // string overload
+		`cidr("192.168.0.0/16").containsIP(payload.client_ip)`:   false,
+		`isCIDR("10.0.0.0/8") && !isCIDR(payload.client_ip)`:     true,
+		`ip(payload.client_ip).family() == 4`:                    true,
+		`!ip(payload.client_ip).isLoopback()`:                    true,
+		`cidr("10.0.0.0/8").containsCIDR(cidr("10.1.0.0/16"))`:   true,
+		`cidr("10.0.0.0/8").containsCIDR(cidr("172.16.0.0/12"))`: false,
+	}
+	for expr, want := range tests {
+		if got := eval(t, expr); got != want {
+			t.Errorf("eval(%q) = %v, want %v", expr, got, want)
+		}
+	}
+}
+
+func TestEncodersExtension(t *testing.T) {
+	if !eval(t, `base64.encode(bytes(payload.msg)) == "YWJjZGVm"`) {
+		t.Error(`base64.encode(bytes("abcdef")) != "YWJjZGVm"`)
+	}
+	if !eval(t, `string(base64.decode("YWJjZGVm")) == payload.msg`) {
+		t.Error(`base64.decode round-trip failed`)
+	}
+	// EncodersVersion(0) pins base64 only: json.encode must not exist (toJSON
+	// remains the single JSON spelling).
+	if _, err := Compile(`json.encode(payload) != ""`); err == nil {
+		t.Error(`json.encode compiled; want unknown-function error (EncodersVersion(0))`)
 	}
 }
 


### PR DESCRIPTION
## What

Follow-up to #35 (cel-go v0.28.1 → v0.29.1): adopt the two v0.29.0 additions that fit the `whenExpr` gate.

**`ext.Network()`** — the Kubernetes CEL network library, upstreamed in cel-go v0.29. Gates can now filter on IPs in payloads:

```yaml
whenExpr: cidr("10.0.0.0/8").containsIP(payload.client_ip)
```

Full surface: `ip()`, `cidr()`, `isIP()`, `isCIDR()`, containment (`containsIP`/`containsCIDR`, with string overloads), and inspection (`family()`, `isLoopback()`, `masked()`, `prefixLength()`, …). The library's documented collision caveat (it defines global `ip`/`cidr`/`isIP`/`isCIDR`) doesn't apply — the env's variables are `payload`/`headers`/`query`/`method`/`route`/`now`.

**`ext.Encoders(ext.EncodersVersion(0))`** — `base64.encode`/`base64.decode`, deliberately pinned to version 0. Version 1 would also add `json.encode`, which duplicates the documented `toJSON`; the pin keeps a single JSON spelling, and a test asserts `json.encode` stays absent so a future unpinning is a conscious choice.

## Not adopted from v0.29 (considered)

- **`json.encode`** — duplicate of `toJSON` (above).
- **Managed execution frame / `InterpretableV2`** — internal async foundations, nothing to call.
- **CEL policy conformance runner** — chaski doesn't use the policy framework.
- Free with #35 regardless: expression-size limit enforced before parse, `has()` unknown-propagation fix, optional-unwrapping fix.

## Testing

- `TestNetworkExtension`: containment true/false, string overload, `isIP`/`isCIDR`, `family()`, `isLoopback()`, CIDR-in-CIDR.
- `TestEncodersExtension`: base64 round-trip + the `json.encode`-absent pin.
- `go test ./...` green; `golangci-lint` clean.

README documents the gate's full function surface (strings + network extensions, base64, `toJSON`, `truncate`) in the Templating section.
