### PR TITLE
fix(relay): correctness — sibling cancellation, apprise timeout, nil-config panic, timeout plumbing

### DIFF
--- a/cmd/chaski/main.go
+++ b/cmd/chaski/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"runtime"
@@ -60,6 +61,13 @@ func run() error {
 	if err != nil {
 		return err
 	}
+
+	// apprise-go sends through the shared http.DefaultClient, which has no
+	// timeout and takes no context — so a hung notification endpoint would pin a
+	// goroutine and socket indefinitely, past the request deadline. Bounding the
+	// default client here is the only in-process way to cap those sends. chaski's
+	// own HTTP sink uses its own client, so this affects only apprise delivery.
+	http.DefaultClient.Timeout = cfg.RequestTimeout
 
 	logger := newLogger(cfg)
 	slog.SetDefault(logger)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -192,10 +192,18 @@ func decodeFragment(data []byte, name string) (*RouteConfig, error) {
 		return nil, fmt.Errorf("config: parsing %q: %w", name, err)
 	}
 
-	for _, r := range rc.Routes {
+	// A valueless key ("routes:\n  r:\n") decodes to a nil entry; reject it with
+	// a clear, provenance-bearing error rather than panicking downstream.
+	for rn, r := range rc.Routes {
+		if r == nil {
+			return nil, fmt.Errorf("config: %q: route %q has no configuration", name, rn)
+		}
 		r.Source = name
 	}
-	for _, t := range rc.Targets {
+	for tn, t := range rc.Targets {
+		if t == nil {
+			return nil, fmt.Errorf("config: %q: target %q has no configuration", name, tn)
+		}
 		t.Source = name
 	}
 	if len(rc.Templates) > 0 {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -203,6 +203,27 @@ func TestDuplicateNamesAreFatal(t *testing.T) {
 	}
 }
 
+func TestNilEntryIsErrorNotPanic(t *testing.T) {
+	// A valueless route/target key decodes to a nil entry; it must yield a clean,
+	// provenance-bearing config error rather than a nil-pointer panic downstream.
+	for _, tc := range []struct{ name, body, want string }{
+		{"route", "targets:\n  t: {apprise: {url: 'pover://u@t/'}}\nroutes:\n  r:\n", `route "r" has no configuration`},
+		{"target", "targets:\n  t:\n", `target "t" has no configuration`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			write(t, filepath.Join(dir, "c.yaml"), tc.body)
+			_, err := LoadRouteConfig(dir)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want containing %q", err, tc.want)
+			}
+			if !strings.Contains(err.Error(), "c.yaml") {
+				t.Errorf("error should name the fragment: %v", err)
+			}
+		})
+	}
+}
+
 func TestDuplicateTargetInRouteRejected(t *testing.T) {
 	dir := t.TempDir()
 	write(t, filepath.Join(dir, "c.yaml"),

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -38,8 +38,9 @@ type Options struct {
 // template, verify block, or target reference.
 func Build(rc *config.RouteConfig, cfg *config.Config, opts Options) (*Engine, error) {
 	sinkOpts := sink.Options{
-		Notifier:     opts.Notifier,
-		DefaultRetry: sink.RetryPolicy{Attempts: cfg.RetryAttempts, Backoff: cfg.RetryBackoff},
+		Notifier:       opts.Notifier,
+		DefaultRetry:   sink.RetryPolicy{Attempts: cfg.RetryAttempts, Backoff: cfg.RetryBackoff},
+		DefaultTimeout: cfg.RequestTimeout, // http target default when it sets no timeout
 	}
 
 	sinks := make(map[string]sink.Sink, len(rc.Targets))
@@ -357,9 +358,12 @@ func (r *Route) fanOut(ctx context.Context, rr rendered, in Input, matched []boo
 		return 0, nil
 	}
 
-	g, gctx := errgroup.WithContext(ctx)
+	// Plain errgroup (not WithContext): one target failing must not cancel the
+	// other targets' in-flight sends and retries — each matched target gets its
+	// full attempt, bounded only by the request ctx. Wait returns the first error.
+	var g errgroup.Group
 	for _, j := range jobs {
-		g.Go(func() error { return j.s.Send(gctx, j.msg) })
+		g.Go(func() error { return j.s.Send(ctx, j.msg) })
 	}
 	return len(jobs), g.Wait()
 }

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -364,6 +365,54 @@ routes:
 			t.Errorf("kind=%v status=%d, want RelayError 502", res.Kind, res.Status)
 		}
 	})
+}
+
+// siblingNotifier fails target "a" instantly and makes target "b" a slow send
+// that records whether it ran to completion or was cancelled mid-flight.
+type siblingNotifier struct {
+	mu         sync.Mutex
+	bDelivered bool
+	bCancelled bool
+}
+
+func (f *siblingNotifier) Send(ctx context.Context, targetURL, _, _ string, _ map[string]string) error {
+	if strings.Contains(targetURL, "//a@") {
+		return errors.New("boom") // fast failure
+	}
+	select {
+	case <-time.After(100 * time.Millisecond): // in-flight send that outlasts a's failure
+		f.mu.Lock()
+		f.bDelivered = true
+		f.mu.Unlock()
+		return nil
+	case <-ctx.Done():
+		f.mu.Lock()
+		f.bCancelled = true
+		f.mu.Unlock()
+		return ctx.Err()
+	}
+}
+
+func TestFanOutFailureDoesNotCancelSiblings(t *testing.T) {
+	const y = `
+targets:
+  a: { apprise: { url: 'pover://a@t/' } }
+  b: { apprise: { url: 'pover://b@t/' } }
+routes:
+  r: { target: [a, b], message: 'hi' }
+`
+	fn := &siblingNotifier{}
+	res := handle(route(t, engine(t, y, fn)), map[string]any{}, false)
+	// a's failure still surfaces as a 502...
+	if res.Kind != relay.RelayError || res.Status != 502 {
+		t.Errorf("kind=%v status=%d, want RelayError 502", res.Kind, res.Status)
+	}
+	// ...but b's send must have completed, not been cancelled by a.
+	fn.mu.Lock()
+	defer fn.mu.Unlock()
+	if !fn.bDelivered || fn.bCancelled {
+		t.Errorf("sibling delivered=%v cancelled=%v, want delivered and not cancelled", fn.bDelivered, fn.bCancelled)
+	}
 }
 
 func TestResponseStatusOverride(t *testing.T) {


### PR DESCRIPTION
Batch A of the review (correctness). Four verified findings:

**1. Fan-out cancelled healthy siblings on the first failure** (high) — `relay.go:fanOut` used `errgroup.WithContext`; the first target's error cancelled the shared ctx, and `sink.withRetry` bails on `ctx.Err()`, so a healthy target's in-flight send/retries were aborted → notification silently lost (stateless, no queue). Now a plain `errgroup.Group` with the request ctx passed directly; the 502-on-any-failure mapping is unchanged. **Test:** `TestFanOutFailureDoesNotCancelSiblings` (fast-fail target a + slow target b → b still delivers, not cancelled).

**2. Apprise sends had no deadline** (high) — apprise-go uses the shared `http.DefaultClient` (no timeout, no ctx), so a hung provider endpoint pinned a goroutine + socket past `RequestTimeout`. Bounded `http.DefaultClient.Timeout = cfg.RequestTimeout` at startup (per your call). chaski's HTTP sink uses its own client, so only apprise delivery is affected.

**3. Nil route/target entry panicked** (high, crash) — `routes:\n  r:\n` (valueless key) decoded to a nil `*Route` → SIGSEGV at `load.go` on both boot and `chaski validate`. Now a clean `config: "c.yaml": route "r" has no configuration`. **Test:** `TestNilEntryIsErrorNotPanic`.

**4. `CHASKI_REQUEST_TIMEOUT` never reached http sinks** (med) — `relay.Build` built `sink.Options` without `DefaultTimeout`, so http targets ignored the documented default and always used the hard-coded 10s. Now plumbed.

`go test -race ./...` green; `golangci-lint` clean.
