### PR TITLE
fix(server): always serve /healthz on the monitoring port; record panicked requests

### DIFF
--- a/charts/chaski/templates/deployment.tpl
+++ b/charts/chaski/templates/deployment.tpl
@@ -119,11 +119,11 @@ spec:
             - name: http
               containerPort: {{ .Values.config.port }}
               protocol: TCP
-            {{- if .Values.config.metricsEnabled }}
+            # Always exposed: this port serves /healthz (the probes) even when
+            # metrics are disabled; /metrics is served here only when metricsEnabled.
             - name: metrics
               containerPort: {{ .Values.config.metricsPort }}
               protocol: TCP
-            {{- end }}
             {{- if .Values.config.smtpEnabled }}
             - name: smtp
               containerPort: {{ .Values.config.smtpPort }}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -24,9 +24,11 @@ func (s *Server) handler() http.Handler {
 	mux.HandleFunc("/", handleNotFound)
 
 	var h http.Handler = mux
-	h = s.observe(h)
-	h = securityHeaders(h)
+	// observe is outermost so its deferred recording sees the final status —
+	// including a 500 written by the (now inner) recoverer for a panicking handler.
 	h = recoverer(s.log)(h)
+	h = securityHeaders(h)
+	h = s.observe(h)
 	return h
 }
 

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -64,10 +64,14 @@ func (s *Server) observeRelay(route string, res relay.Result) {
 // metricsHandler serves Prometheus metrics and the health/readiness probe on
 // the dedicated monitoring listener, so scraping and probing share one port
 // (8081 by default) separate from the public webhook port.
-func metricsHandler() http.Handler {
+func metricsHandler(metricsEnabled bool) http.Handler {
 	mux := http.NewServeMux()
-	mux.Handle("GET /metrics", promhttp.Handler())
+	// /healthz is always served: the liveness/readiness probe must work even when
+	// Prometheus metrics are disabled, so the pod can still become Ready.
 	mux.HandleFunc("GET /healthz", handleHealth)
+	if metricsEnabled {
+		mux.Handle("GET /metrics", promhttp.Handler())
+	}
 	return mux
 }
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -68,13 +68,17 @@ func (s *Server) observe(next http.Handler) http.Handler {
 		start := time.Now()
 		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 
-		next.ServeHTTP(rec, r)
+		// Record in a defer so a panic recovered by the inner recoverer (which
+		// writes 500 to rec) is still counted and access-logged, with its status.
+		defer func() {
+			duration := time.Since(start)
+			method := methodLabel(r.Method)
+			httpRequests.WithLabelValues(method, statusClass(rec.status)).Inc()
+			httpDuration.WithLabelValues(method).Observe(duration.Seconds())
+			s.logRequest(r, rec.status, duration)
+		}()
 
-		duration := time.Since(start)
-		method := methodLabel(r.Method)
-		httpRequests.WithLabelValues(method, statusClass(rec.status)).Inc()
-		httpDuration.WithLabelValues(method).Observe(duration.Seconds())
-		s.logRequest(r, rec.status, duration)
+		next.ServeHTTP(rec, r)
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -57,11 +57,11 @@ func (s *Server) Run(ctx context.Context) error {
 	webhookSrv := newHTTPServer(fmt.Sprintf(":%d", s.cfg.HTTPPort), s.handler())
 	g.Go(func() error { return serve(webhookSrv, "webhook", s.log) })
 
-	var metricsSrv *http.Server
-	if s.cfg.MetricsEnabled {
-		metricsSrv = newHTTPServer(fmt.Sprintf(":%d", s.cfg.MetricsPort), s.accessLog(metricsHandler()))
-		g.Go(func() error { return serve(metricsSrv, "metrics", s.log) })
-	}
+	// The monitoring listener always runs: it serves /healthz (liveness/readiness)
+	// regardless of whether Prometheus /metrics is enabled, so disabling metrics
+	// can't leave the pod without a health endpoint. MetricsEnabled gates /metrics.
+	monitoringSrv := newHTTPServer(fmt.Sprintf(":%d", s.cfg.MetricsPort), s.accessLog(metricsHandler(s.cfg.MetricsEnabled)))
+	g.Go(func() error { return serve(monitoringSrv, "monitoring", s.log) })
 
 	var smtpSrv *smtp.Server
 	if s.cfg.SMTPEnabled {
@@ -75,7 +75,7 @@ func (s *Server) Run(ctx context.Context) error {
 		sctx, cancel := context.WithTimeout(context.Background(), s.cfg.ShutdownTimeout)
 		defer cancel()
 		shutdown(sctx, webhookSrv)
-		shutdown(sctx, metricsSrv)
+		shutdown(sctx, monitoringSrv)
 		smtpSrv.Shutdown(sctx)
 		return nil
 	})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -133,9 +133,10 @@ func TestRequestLogLevels(t *testing.T) {
 	}
 }
 
-func TestHealthz(t *testing.T) {
+func TestHealthzServedEvenWhenMetricsDisabled(t *testing.T) {
 	rec := httptest.NewRecorder()
-	metricsHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	// metrics off: /healthz must still work, so probes keep the pod Ready.
+	metricsHandler(false).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"status":"ok"`) {
 		t.Fatalf("healthz: %d %q", rec.Code, rec.Body.String())
 	}
@@ -143,9 +144,15 @@ func TestHealthz(t *testing.T) {
 
 func TestMetricsEndpoint(t *testing.T) {
 	rec := httptest.NewRecorder()
-	metricsHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	metricsHandler(true).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("metrics status = %d", rec.Code)
+	}
+	// metrics off: /metrics is not registered (404).
+	rec = httptest.NewRecorder()
+	metricsHandler(false).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("metrics disabled: status = %d, want 404", rec.Code)
 	}
 }
 


### PR DESCRIPTION
Batch B of the review (ops/health).

**1. `metricsEnabled: false` → never-Ready pod** (med) — `/healthz` lived only on the metrics listener, which was gated on `MetricsEnabled`, and the probes target that port. Disabling metrics left the pod with no health endpoint → liveness restart-loop, no `fail` guard. Now the monitoring listener **always runs** and serves `/healthz`; `MetricsEnabled` gates only `/metrics` registration, and the chart always renders the port. Verified: `helm template --set config.metricsEnabled=false` still renders the `metrics` port + probes; `metricsHandler(false)` serves `/healthz` (200) and 404s `/metrics`.

**2. Panicked requests missing from metrics + access log** (low) — `observe` recorded *after* `next.ServeHTTP` returned, and was inside the recoverer, so a panicking request unwound past the recording lines. Now `observe` records in a `defer` and is the outermost middleware, so a recovered panic is counted and logged with its 500 status.

**Not included:** preStop drain hook — chaski is distroless (no shell for `exec` sleep) and the native `sleep` preStop handler needs k8s ≥1.30; given the app already drains gracefully and sender retries mask the brief Endpoints window, I left it out. Easy to add behind a value if you want it.

`go test -race ./...`, `golangci-lint`, `helm lint`, and `helm unittest` (19/19) all green.
