### PR TITLE
fix(server,sink): stop leaking secrets via dry-run, error bodies, and logs

### DIFF
--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -407,12 +407,31 @@ type PlanTarget struct {
 	Skipped bool              `json:"skipped,omitempty"`
 }
 
+// maskValues returns m with every value replaced by a fixed placeholder, so a
+// dry-run plan can show which keys render without disclosing their (possibly
+// secret) rendered values. Returns nil for an empty map (omitted from JSON).
+func maskValues(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k := range m {
+		out[k] = "***"
+	}
+	return out
+}
+
 func (r *Route) plan(rr rendered, in Input, matched []bool) *Plan {
 	p := &Plan{Route: r.name, Fired: true}
 	for i, t := range r.targets {
 		pt := PlanTarget{Name: t.sink.Name(), Kind: t.sink.Kind()}
 		if msg, ok := messageFor(t.sink, rr, in); ok && matched[i] {
-			pt.Title, pt.Body, pt.Params, pt.Headers = msg.Title, msg.Body, msg.Params, msg.Headers
+			// Title/Body are the notification content the dry run exists to preview.
+			// Params/Headers values are masked (keys kept): a route-level header or
+			// param can render a {{ env }} secret, and an unauthenticated ?dryRun=1
+			// caller must not read it — like the target URL, which is never included.
+			pt.Title, pt.Body = msg.Title, msg.Body
+			pt.Params, pt.Headers = maskValues(msg.Params), maskValues(msg.Headers)
 		} else {
 			pt.Skipped = true
 		}

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -415,6 +415,34 @@ routes:
 	}
 }
 
+// TestDryRunMasksHeaderAndParamValues pins that the dry-run plan shows which
+// route header/param keys render but masks their values, so a {{ env }} secret
+// in a route-level header/param isn't disclosed to a ?dryRun=1 caller.
+func TestDryRunMasksHeaderAndParamValues(t *testing.T) {
+	const my = `
+targets:
+  po: { apprise: { url: 'pover://u@t/' } }
+  bridge: { http: { url: 'https://x.internal/i' } }
+routes:
+  r:
+    target: [po, bridge]
+    message: 'body'
+    params: { priority: '{{ .payload.tok }}' }
+    headers: { X-Auth: 'Bearer {{ .payload.tok }}' }
+`
+	r := route(t, engine(t, my, &fakeNotifier{}))
+	res := handle(r, map[string]any{"tok": "s3cr3t"}, true)
+	if res.Plan == nil {
+		t.Fatal("dry run returned no plan")
+	}
+	if po := planTarget(t, res.Plan, "po"); po.Params["priority"] != "***" {
+		t.Errorf("apprise param value = %q, want masked ***", po.Params["priority"])
+	}
+	if b := planTarget(t, res.Plan, "bridge"); b.Headers["X-Auth"] != "***" {
+		t.Errorf("http header value = %q, want masked ***", b.Headers["X-Auth"])
+	}
+}
+
 func TestResponseStatusOverride(t *testing.T) {
 	const y = `
 targets: { po: { apprise: { url: 'pover://u@t/' } } }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -103,11 +103,11 @@ func (s *Server) handleHook(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case res.Plan != nil:
 		writeJSON(w, res.Status, res.Plan)
-	case (res.Kind == relay.GateError || res.Kind == relay.RenderError) && res.Err != nil:
-		// Operator-fault: surface the cause. These carry no payload body or target
-		// credentials (unlike a relay/502 error, which stays generic below).
-		writeError(w, res.Status, res.Err.Error())
 	case res.Status >= http.StatusInternalServerError:
+		// Generic to the caller. Gate/render errors wrap the operator's expression
+		// or template source (env-var names, and a value if piped through e.g.
+		// atoi) — that detail goes to logs (observeRelay above), never the client,
+		// which a caller who can trigger a 500 must not read.
 		writeError(w, res.Status, http.StatusText(res.Status))
 	default:
 		w.WriteHeader(res.Status)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -246,7 +246,7 @@ func TestDryRunGateFalseReturnsPlan(t *testing.T) {
 	}
 }
 
-func TestRenderErrorSurfacesCause(t *testing.T) {
+func TestRenderErrorIsGenericToClient(t *testing.T) {
 	const y = `
 targets: { po: { apprise: { url: 'pover://u@t/' } } }
 routes:
@@ -271,9 +271,14 @@ routes:
 		t.Fatalf("status = %d, want 500", rec.Code)
 	}
 	body := rec.Body.String()
-	if !strings.Contains(body, "message") || strings.Contains(body, "Internal Server Error") {
-		t.Errorf("500 body = %s, want the render cause (not the generic text)", body)
+	// Generic to the client; the operator's template source must not leak.
+	if !strings.Contains(body, "Internal Server Error") {
+		t.Errorf("500 body = %s, want the generic status text", body)
 	}
+	if strings.Contains(body, "Bad") || strings.Contains(body, "payload") {
+		t.Errorf("500 body leaks template source: %s", body)
+	}
+	// The low-cardinality outcome label is still exposed (not the cause).
 	if got := rec.Header().Get("X-Chaski-Result"); got != "render_error" {
 		t.Errorf("header = %q, want render_error", got)
 	}

--- a/internal/sink/apprise.go
+++ b/internal/sink/apprise.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 
 	apprise "github.com/unraid/apprise-go"
 )
@@ -34,9 +35,23 @@ func (appriseNotifier) Send(ctx context.Context, targetURL, body, title string, 
 		opts = append(opts, apprise.WithTitle(title))
 	}
 	if err := a.Send(body, opts...); err != nil {
-		return fmt.Errorf("apprise: send: %w", err)
+		// apprise-go embeds the full, credential-bearing target URL in its error
+		// text. Strip the known URL strings so it can't reach logs. Best-effort:
+		// a fully robust fix needs apprise-go to stop echoing the URL.
+		return fmt.Errorf("apprise: send failed: %s", redactURLs(err.Error(), full, targetURL))
 	}
 	return nil
+}
+
+// redactURLs replaces each non-empty url in text with a placeholder — used to
+// strip credential-bearing target URLs that apprise-go echoes in its errors.
+func redactURLs(text string, urls ...string) string {
+	for _, u := range urls {
+		if u != "" {
+			text = strings.ReplaceAll(text, u, "<redacted-url>")
+		}
+	}
+	return text
 }
 
 // mergeQuery URL-encodes params into rawURL's query (params override existing

--- a/internal/sink/http.go
+++ b/internal/sink/http.go
@@ -2,9 +2,11 @@ package sink
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/home-operations/chaski/internal/config"
@@ -64,7 +66,9 @@ func (s *httpSink) do(ctx context.Context, msg Message) error {
 	}
 	req, err := http.NewRequestWithContext(ctx, s.method, s.url, body)
 	if err != nil {
-		return Permanent(fmt.Errorf("http: build request: %w", err))
+		// The build error would echo the (possibly credentialed) URL; name the
+		// target instead. Config validation catches a malformed URL earlier.
+		return Permanent(fmt.Errorf("http target %q: build request failed", s.name))
 	}
 	// Route headers first, then the target's static headers — the target wins on
 	// any conflict, so a route header can't override the target's Authorization
@@ -81,7 +85,13 @@ func (s *httpSink) do(ctx context.Context, msg Message) error {
 
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("http: %s %s: %w", s.method, s.url, err) // transport/timeout — retryable
+		// *url.Error embeds the URL, and s.url may carry credentials in its query;
+		// unwrap to the transport cause and identify the target by name instead.
+		var ue *url.Error
+		if errors.As(err, &ue) {
+			err = ue.Err
+		}
+		return fmt.Errorf("http target %q: %w", s.name, err) // transport/timeout — retryable
 	}
 	defer func() {
 		_, _ = io.Copy(io.Discard, resp.Body)
@@ -92,8 +102,8 @@ func (s *httpSink) do(ctx context.Context, msg Message) error {
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
 		return nil
 	case resp.StatusCode >= 400 && resp.StatusCode < 500:
-		return Permanent(fmt.Errorf("http: %s %s: status %d", s.method, s.url, resp.StatusCode))
+		return Permanent(fmt.Errorf("http target %q: status %d", s.name, resp.StatusCode))
 	default:
-		return fmt.Errorf("http: %s %s: status %d", s.method, s.url, resp.StatusCode) // 5xx — retryable
+		return fmt.Errorf("http target %q: status %d", s.name, resp.StatusCode) // 5xx — retryable
 	}
 }

--- a/internal/sink/sink_test.go
+++ b/internal/sink/sink_test.go
@@ -154,6 +154,37 @@ func TestHTTPSink5xxRetriedThen4xxNot(t *testing.T) {
 	})
 }
 
+// TestHTTPSinkErrorsOmitURL pins that a delivery error never contains the target
+// URL — which may carry credentials in its query — so it can't leak to logs.
+func TestHTTPSinkErrorsOmitURL(t *testing.T) {
+	const secretURL = "http://127.0.0.1:1/ingest?apikey=s3cr3t"
+	t.Run("transport error", func(t *testing.T) {
+		s, _ := New("bridge", httpTarget(secretURL, "POST"), Options{DefaultRetry: fastRetry})
+		err := s.Send(context.Background(), Message{Body: "b"})
+		if err == nil || strings.Contains(err.Error(), "s3cr3t") || strings.Contains(err.Error(), "apikey") {
+			t.Fatalf("error leaks the URL: %v", err)
+		}
+	})
+	t.Run("5xx status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		}))
+		defer srv.Close()
+		s, _ := New("bridge", httpTarget(srv.URL+"?apikey=s3cr3t", "POST"), Options{DefaultRetry: fastRetry})
+		err := s.Send(context.Background(), Message{Body: "b"})
+		if err == nil || strings.Contains(err.Error(), "s3cr3t") {
+			t.Fatalf("status error leaks the URL query: %v", err)
+		}
+	})
+}
+
+func TestRedactURLs(t *testing.T) {
+	got := redactURLs("send to discord://id/token failed: 401", "discord://id/token")
+	if strings.Contains(got, "token") {
+		t.Errorf("redactURLs left the URL: %q", got)
+	}
+}
+
 func TestNewBuildsSinks(t *testing.T) {
 	a, err := New("po", &config.Target{Apprise: &config.AppriseSink{URL: "pover://u@t/"}}, Options{})
 	if err != nil || a.Kind() != "apprise" {


### PR DESCRIPTION
Batch C of the review (disclosure hardening). Per your calls: mask dry-run values / generic error to client / bound apprise elsewhere.

**#7 — `?dryRun=1` leaked rendered route headers/params** (med, flagged twice) — the plan redacted *target* creds but echoed rendered *route-level* `headers`/`params`, which can carry `{{ env }}` secrets. Now their **values are masked** (`"***"`, keys kept — the plan still shows structure); `Title`/`Body` (the content the dry run exists to preview) are unchanged.

**#8 — gate/render 500s echoed the operator's source** (low/med) — a wrong-shaped payload forced a 500 whose body was the expression/template source (env-var names; a value if piped through e.g. `atoi`). Now generic status text to the client; the full cause still goes to logs via `observeRelay`. (This reverses the actionable-error-body from #8 — your call.)

**#9 — delivery errors logged target URLs (with creds)** (med) — the sinks embedded the target URL in errors logged at Error. `http` now unwraps `*url.Error` and names the target instead of the URL (query creds could ride along); `apprise` redacts the known URL strings apprise-go bundles in its error text (best-effort — a full fix needs apprise-go to stop echoing the URL; noted).

Tests added: dry-run masking, render-500 body is generic + leaks no source, http transport/status errors omit the URL+query, `redactURLs`. `go test -race ./...`, `golangci-lint`, `helm` all green.

**Not fixed here** (needs upstream): apprise 4xx is still retried as retryable — apprise-go returns an internal `HTTPStatusError` chaski can't classify, so distinguishing permanent 4xx needs an apprise-go change.
