### PR TITLE
docs: pushover format param (html/markdown) via apprise-go v0.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ A notification through [apprise-go](https://github.com/unraid/apprise-go): the
 URL scheme picks the provider and carries its credentials. A route's `params`
 are URL-encoded onto the target URL's query, so the keys you set are whatever
 the chosen provider recognizes — Pushover, for example, reads `priority`,
-`sound`, `url`, and `url_title`.
+`sound`, `url`, `url_title`, and `format` (`html` | `markdown`; renders the
+message instead of showing it as plain text).
 
 ```yaml
 targets:


### PR DESCRIPTION
apprise-go v0.2.7 (#40) wires Pushover message formatting as a `format` query param (`html` passes the body through with `html=1`; `markdown` converts to HTML first). chaski's `params` map already URL-encodes onto the target URL, so `params: {format: html}` works with no code change — this just documents the new key.

Note the wired key is `format`, not `html` — `html: "1"` in params remains a no-op (it was schema-declared but unwired in ≤v0.2.6).

Merge after #40.