### PR TITLE
docs: pushover format applies to the message only, never the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ URL scheme picks the provider and carries its credentials. A route's `params`
 are URL-encoded onto the target URL's query, so the keys you set are whatever
 the chosen provider recognizes — Pushover, for example, reads `priority`,
 `sound`, `url`, `url_title`, and `format` (`html` | `markdown`; renders the
-message instead of showing it as plain text).
+message instead of showing it as plain text — Pushover titles never render
+HTML, so keep tags out of `title`).
 
 ```yaml
 targets:


### PR DESCRIPTION
Pushover's `html=1` renders the message body only — titles are plain text on every client, so HTML tags in a route's `title` always show literally (apprise-go v0.2.7 correctly leaves titles untouched). Documents the trap next to the `format` param.