### PR TITLE
fix(sink): pass params format as the apprise input format

### DIFF
--- a/internal/sink/apprise.go
+++ b/internal/sink/apprise.go
@@ -34,6 +34,12 @@ func (appriseNotifier) Send(ctx context.Context, targetURL, body, title string, 
 	if title != "" {
 		opts = append(opts, apprise.WithTitle(title))
 	}
+	// A route that sets format declares its body IS that format. Without this,
+	// apprise-go's default input format (text) HTML-escapes the body when
+	// converting for an html/markdown target, so tags render literally.
+	if f := params["format"]; f != "" {
+		opts = append(opts, apprise.WithInputFormat(f))
+	}
 	if err := a.Send(body, opts...); err != nil {
 		// apprise-go embeds the full, credential-bearing target URL in its error
 		// text. Strip the known URL strings so it can't reach logs. Best-effort:


### PR DESCRIPTION
## What

`params: {format: html}` on a route still produced literal `<b>` tags on Pushover even after apprise-go v0.2.7 wired the format param. Root cause: chaski calls `apprise.Send` without `WithInputFormat`, which defaults to `text` — so apprise-go's `ConvertMessageFormatForTarget` runs a text→html conversion on the way to any `?format=html` target, and that conversion is `escapeHTML`. The body reaches Pushover as `&lt;b&gt;…`, which its clients display literally.

The fix mirrors what the apprise CLI flow did (`--input-format html` paired with `?format=html`): a route that sets `format` is declaring its body **is** authored in that format, so pass the same value as the input format. Input == output → conversion is a no-op → tags reach Pushover intact alongside `html=1`.

No behavior change for routes without `format` (input stays `text`, and targets without an output format never convert). `format: markdown` also works end-to-end: the body passes through unconverted and the pushover target does the markdown→HTML rendering itself.