### PR TITLE
feat(ci): goreleaser Pro — release binaries + Homebrew cask

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ on:
       - main
     paths-ignore:
       - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
   release:
     types:
       - published
@@ -19,6 +22,7 @@ concurrency:
 jobs:
   versions:
     name: Versions
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -41,8 +45,10 @@ jobs:
         id: versions
         run: echo "go-version=$(mise config get tools.go)" >> "$GITHUB_OUTPUT"
 
+  # Publishes images — never runs for PRs (stronger than a fork gate).
   release:
     name: Release
+    if: ${{ github.event_name != 'pull_request' }}
     needs: versions
     permissions:
       contents: read
@@ -118,3 +124,139 @@ jobs:
 
       - name: Sign the published chart with Cosign
         run: cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/chaski:${VERSION}"
+
+  # goreleaser Pro split/merge: one build job per GOOS, each writing a
+  # self-contained dist/<goos> handed to the merge job as an artifact.
+  # Snapshot runs on PRs and main pushes exercise the pipeline (keyless —
+  # fork PRs work) and save the Go caches on main — tag runs can only
+  # restore caches saved on the default branch.
+  goreleaser-split:
+    name: GoReleaser (${{ matrix.goos }})
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, darwin, windows]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          cache: false
+          experimental: true
+          install_args: --locked
+
+      - name: Install UPX
+        uses: crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368 # v4.0.0
+        with:
+          install-only: true
+
+      # Keyed per GOOS: GOCACHE entries differ per target. cache-poisoning
+      # rationale in .github/zizmor.yml.
+      - name: Cache Go build outputs
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: goreleaser-go-${{ matrix.goos }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            goreleaser-go-${{ matrix.goos }}-
+
+      - name: Run GoReleaser (split snapshot)
+        if: ${{ github.event_name != 'release' }}
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser-pro # split/merge + versioned casks are Pro features
+          version: "~> v2"
+          args: release --clean --split --snapshot
+        env:
+          # GGOOS filters targets without leaking into hooks (GOOS would).
+          GGOOS: ${{ matrix.goos }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - name: Run GoReleaser (split)
+        if: ${{ github.event_name == 'release' }}
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser-pro # split/merge + versioned casks are Pro features
+          version: "~> v2"
+          args: release --clean --split
+        env:
+          GGOOS: ${{ matrix.goos }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - name: Upload partial dist
+        if: ${{ github.event_name == 'release' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist-${{ matrix.goos }}
+          path: dist
+          if-no-files-found: error
+          retention-days: 1
+
+  # Checksums/signing/SBOMs/publish over the combined dist/ — never rebuilds.
+  goreleaser-merge:
+    name: GoReleaser (merge)
+    if: ${{ github.event_name == 'release' }}
+    needs: goreleaser-split
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          cache: false
+          experimental: true
+          install_args: --locked
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Download partial dists
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
+
+      - name: Generate Homebrew Tap Token
+        id: tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: homebrew-tap
+          permission-contents: write
+
+      - name: Run GoReleaser (merge)
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser-pro # split/merge + versioned casks are Pro features
+          version: "~> v2"
+          args: continue --merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.tap-token.outputs.token }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,8 +1,8 @@
-# The Helm E2E build (e2e.yaml) runs docker/build-push-action with `load: true`:
-# the image is loaded into the kind cluster for the test and never pushed to a
-# registry or released. There is therefore no published artifact for a poisoned
-# tool/layer cache to compromise, so cache-poisoning does not apply to that job.
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/zizmorcore/zizmor/main/docs/schemas/zizmor.schema.json
 rules:
+  # Go cache on the goreleaser split legs: tag runs only restore caches saved
+  # from main, and PRs can't write those (PR cache saves are scoped to the PR).
   cache-poisoning:
     ignore:
-      - e2e.yaml
+      - release.yaml

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,98 @@
+---
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+version: 2
+project_name: chaski
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: chaski
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}}
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    main: ./cmd/chaski
+    binary: chaski
+
+archives:
+  - id: chaski
+    ids:
+      - chaski
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+upx:
+  - enabled: true
+    compress: best
+    lzma: true
+
+checksum:
+  algorithm: sha256
+  split: true
+
+sboms:
+  - artifacts: archive
+    documents:
+      - "{{ .ArtifactName }}.sbom.json"
+
+signs:
+  - cmd: cosign
+    signature: ${artifact}.sigstore.json
+    args:
+      - sign-blob
+      - --bundle=${signature}
+      - --yes
+      - ${artifact}
+    artifacts: all
+    output: true
+
+homebrew_casks:
+  - name: chaski
+    ids:
+      - chaski
+    binaries:
+      - chaski
+    # Versioned casks: @major.minor is overwritten per patch, @major.minor.patch
+    # accumulates one tap file per release.
+    alternative_names:
+      - "chaski@{{ .Major }}.{{ .Minor }}"
+      - "chaski@{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    repository:
+      owner: home-operations
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://github.com/home-operations/chaski
+    description: Small, stateless webhook-to-notification relay
+    # Binaries aren't notarized — strip the quarantine bit so macOS doesn't
+    # block the first run with "developer cannot be verified".
+    hooks:
+      post:
+        install: |
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/chaski"] if OS.mac?
+
+# Parallel per-GOOS release jobs (release.yaml): `release --split` legs +
+# one `continue --merge` job for checksums/signing/SBOMs/publish.
+partial:
+  by: goos
+
+# release-please creates the GitHub Release with the changelog; goreleaser
+# attaches binaries/sboms/sigs to it.
+release:
+  mode: keep-existing

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ routes:
     message: "{{ .payload.commonAnnotations.summary }}"
 ```
 
-Run chaski and send it a webhook. Inbound token auth is off by default — fine
-for cluster-internal senders; set `CHASKI_WEBHOOK_TOKEN` to require a bearer
-token (see [Configuration](#configuration)):
+Run chaski and send it a webhook (`brew install home-operations/tap/chaski`,
+or grab a binary from the releases). Inbound token auth is off by default —
+fine for cluster-internal senders; set `CHASKI_WEBHOOK_TOKEN` to require a
+bearer token (see [Configuration](#configuration)):
 
 ```sh
 CHASKI_CONFIG=./chaski.yaml chaski


### PR DESCRIPTION
## What

Brings chaski's release in line with flate/yayamlls — the same goreleaser Pro split/merge pipeline:

- **Release assets**: per-platform archives (linux/darwin/windows, amd64+arm64, no windows/arm64) with split sha256s, syft SBOMs, and keyless cosign bundles, attached to release-please's releases (`keep-existing`).
- **Homebrew cask** to [home-operations/homebrew-tap](https://github.com/home-operations/homebrew-tap): `brew install home-operations/tap/chaski`, plus `chaski@<major>.<minor>` and `@<major>.<minor>.<patch>` versioned casks. Local `chaski validate` (check configs/templates before pushing to GitOps) is the headline use case for a brew install.
- **Pipeline shape** (identical to flate): 3 parallel `release --split` legs by GOOS + a `continue --merge` publish job; snapshot legs on PRs and main pushes (keyless — fork PRs get full coverage) exercise the pipeline continuously and warm the per-GOOS Go caches that tag runs restore; publish-capable jobs (`Release` images, merge) never run for PRs. cache-poisoning rationale in `.github/zizmor.yml`.

Existing docker-image + helm-chart release jobs are untouched.

## Verified

`goreleaser check` (pro binary, keyless), `actionlint` + `zizmor` clean, `mise run test` green. The snapshot legs run on this PR itself — that's the pipeline proof. First release after merge publishes the cask (uses the org `GORELEASER_KEY` + bot tap token, both already in place).