### PR TITLE
feat: per-route logPayload + CHASKI_LOG_UNKNOWN_ROUTES payload capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ stdin, here too):
 chaski send -c ./chaski.yaml --payload sample.json --route alertmanager
 ```
 
+Don't have a sample payload yet? chaski can capture one from the real sender.
+Set `logPayload: true` on a route to log each verified inbound body (before
+the `whenExpr` gate, so a gate miss still logs), or set
+`CHASKI_LOG_UNKNOWN_ROUTES=true` to log bodies POSTed to routes that don't
+exist yet — point the sender at its final URL, press its test button, and:
+
+```sh
+kubectl logs deploy/chaski | jq 'select(.route == "alertmanager") | .payload' > sample.json
+```
+
+Payload bodies can carry secrets — both switches are off by default; enable
+them deliberately and turn them off when done.
+
 ## Targets
 
 A route relays to one or more named targets; a target is exactly one of two
@@ -376,6 +389,7 @@ from the environment:
 | `CHASKI_LOG_LEVEL`              | `info`                | `debug` \| `info` \| `warn` \| `error`                   |
 | `CHASKI_LOG_FORMAT`             | `json`                | slog handler: `json` or `text`                           |
 | `CHASKI_DISABLE_REQUEST_LOGS`   | `false`               | Silence the per-request access log                       |
+| `CHASKI_LOG_UNKNOWN_ROUTES`     | `false`               | Log bodies POSTed to nonexistent routes (still a 404)    |
 | `CHASKI_SHUTDOWN_TIMEOUT`       | `15s`                 | Graceful drain bound on SIGINT/SIGTERM                   |
 | `CHASKI_SMTP_ENABLED`           | `false`               | Enable the SMTP ingestion listener                       |
 | `CHASKI_SMTP_PORT`              | `8025`                | SMTP listener port (when enabled)                        |

--- a/charts/chaski/README.md
+++ b/charts/chaski/README.md
@@ -76,6 +76,7 @@ Kubernetes: `>=1.25.0-0`
 | config.existingConfigMap | string | `""` | Mount this existing ConfigMap instead of rendering one from `routes`/`targets` (e.g. for a config.d directory of fragments). Set `configPath` to `/config` for directory mode. |
 | config.logFormat | string | `"json"` | Log format (CHASKI_LOG_FORMAT): json or text. |
 | config.logLevel | string | `"info"` | Log level (CHASKI_LOG_LEVEL): debug, info, warn, or error. |
+| config.logUnknownRoutes | bool | `false` | Log bodies POSTed to nonexistent routes, still answering 404 (CHASKI_LOG_UNKNOWN_ROUTES) — payload discovery before a route exists. Pre-verify bodies; enable deliberately, turn off when done. |
 | config.maxBodyBytes | int | `1048576` | Inbound body cap in bytes (CHASKI_MAX_BODY_BYTES). |
 | config.metricsEnabled | bool | `true` | Expose Prometheus metrics + the /healthz probe on `metricsPort` (CHASKI_METRICS_ENABLED). |
 | config.metricsPort | int | `8081` | Metrics + health port (CHASKI_METRICS_PORT); kept off the public webhook port. |

--- a/charts/chaski/templates/deployment.tpl
+++ b/charts/chaski/templates/deployment.tpl
@@ -70,6 +70,8 @@ spec:
               value: {{ .Values.config.logLevel | quote }}
             - name: CHASKI_LOG_FORMAT
               value: {{ .Values.config.logFormat | quote }}
+            - name: CHASKI_LOG_UNKNOWN_ROUTES
+              value: {{ .Values.config.logUnknownRoutes | quote }}
             - name: CHASKI_MAX_BODY_BYTES
               value: {{ .Values.config.maxBodyBytes | int64 | quote }}
             - name: CHASKI_REQUEST_TIMEOUT

--- a/charts/chaski/values.schema.json
+++ b/charts/chaski/values.schema.json
@@ -66,6 +66,12 @@
           "title": "logLevel",
           "type": "string"
         },
+        "logUnknownRoutes": {
+          "default": false,
+          "description": "Log bodies POSTed to nonexistent routes, still answering 404 (CHASKI_LOG_UNKNOWN_ROUTES) — payload discovery before a route exists. Pre-verify bodies; enable deliberately, turn off when done.",
+          "title": "logUnknownRoutes",
+          "type": "boolean"
+        },
         "maxBodyBytes": {
           "default": 1048576,
           "description": "Inbound body cap in bytes (CHASKI_MAX_BODY_BYTES).",

--- a/charts/chaski/values.yaml
+++ b/charts/chaski/values.yaml
@@ -45,6 +45,8 @@ config:
   logLevel: info
   # -- Log format (CHASKI_LOG_FORMAT): json or text.
   logFormat: json
+  # -- Log bodies POSTed to nonexistent routes, still answering 404 (CHASKI_LOG_UNKNOWN_ROUTES) — payload discovery before a route exists. Pre-verify bodies; enable deliberately, turn off when done.
+  logUnknownRoutes: false
   # -- Inbound body cap in bytes (CHASKI_MAX_BODY_BYTES).
   maxBodyBytes: 1048576
   # -- Whole-request deadline (CHASKI_REQUEST_TIMEOUT): decode + gate + render + send + retry.

--- a/config.schema.json
+++ b/config.schema.json
@@ -221,6 +221,10 @@
         "response": {
           "$ref": "#/$defs/Response",
           "description": "Response optionally overrides the status a sender sees (relay vs skip)."
+        },
+        "logPayload": {
+          "type": "boolean",
+          "description": "LogPayload logs each verified inbound body for this route, before the\nwhenExpr gate (so a gate miss still logs) — the payload-capture aid for\nbuilding and tuning routes. Bodies can carry secrets; enable deliberately."
         }
       },
       "additionalProperties": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,11 @@ type Config struct {
 
 	// LogFormat selects the slog handler: "json" (default) or "text".
 	LogFormat string `env:"CHASKI_LOG_FORMAT" envDefault:"json"`
+
+	// LogUnknownRoutes logs the body of a POST to a nonexistent /hooks/ route
+	// (the response stays 404) — payload discovery before the route exists.
+	// These bodies are pre-verify; enable deliberately.
+	LogUnknownRoutes bool `env:"CHASKI_LOG_UNKNOWN_ROUTES" envDefault:"false"`
 	// DisableRequestLogs silences the per-request access log.
 	DisableRequestLogs bool `env:"CHASKI_DISABLE_REQUEST_LOGS" envDefault:"false"`
 

--- a/internal/config/routes.go
+++ b/internal/config/routes.go
@@ -64,6 +64,10 @@ type Route struct {
 	Verify *Verify `yaml:"verify"`
 	// Response optionally overrides the status a sender sees (relay vs skip).
 	Response *Response `yaml:"response"`
+	// LogPayload logs each verified inbound body for this route, before the
+	// whenExpr gate (so a gate miss still logs) — the payload-capture aid for
+	// building and tuning routes. Bodies can carry secrets; enable deliberately.
+	LogPayload bool `yaml:"logPayload"`
 
 	// Source is the fragment file a route was loaded from (provenance for
 	// errors); set by the loader, never decoded.

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -89,16 +89,17 @@ type routeTarget struct {
 
 // Route is one compiled route.
 type Route struct {
-	name      string
-	gate      *gate.Gate
-	verifier  *verify.Verifier
-	title     *render.Template // nil if absent
-	message   *render.Template // nil if omitted (verbatim forward for http)
-	params    *render.Map
-	headers   *render.Map
-	targets   []routeTarget
-	okStatus  int
-	skipState int
+	name       string
+	gate       *gate.Gate
+	verifier   *verify.Verifier
+	title      *render.Template // nil if absent
+	message    *render.Template // nil if omitted (verbatim forward for http)
+	params     *render.Map
+	headers    *render.Map
+	targets    []routeTarget
+	okStatus   int
+	skipState  int
+	logPayload bool
 }
 
 func buildRoute(name string, rt *config.Route, sinks map[string]sink.Sink, set *render.Set) (*Route, error) {
@@ -159,8 +160,12 @@ func buildRoute(name string, rt *config.Route, sinks map[string]sink.Sink, set *
 		name: name, gate: g, verifier: vf,
 		title: title, message: message, params: params, headers: headers,
 		targets: targets, okStatus: ok, skipState: skip,
+		logPayload: rt.LogPayload,
 	}, nil
 }
+
+// LogPayload reports whether the route asks for inbound-payload logging.
+func (r *Route) LogPayload() bool { return r.logPayload }
 
 // Verify runs the route's inbound signature check (a nil verifier accepts).
 func (r *Route) Verify(h http.Header, rawBody []byte) bool {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -57,6 +57,9 @@ func (s *Server) handleHook(w http.ResponseWriter, r *http.Request) {
 
 	route, ok := s.engine.Lookup(r.PathValue("route"))
 	if !ok {
+		if s.cfg.LogUnknownRoutes {
+			s.logUnknownRoute(w, r)
+		}
 		webhookRejected.WithLabelValues("not_found").Inc()
 		handleNotFound(w, r)
 		return
@@ -81,6 +84,12 @@ func (s *Server) handleHook(w http.ResponseWriter, r *http.Request) {
 		webhookRejected.WithLabelValues("decode").Inc()
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
+	}
+
+	// Post-verify, pre-gate: a whenExpr miss still logs — that is when the
+	// payload is needed most.
+	if route.LogPayload() {
+		s.log.Info("inbound payload", "route", r.PathValue("route"), "payload", payload)
 	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), s.cfg.RequestTimeout)
@@ -114,6 +123,20 @@ func (s *Server) handleHook(w http.ResponseWriter, r *http.Request) {
 	default:
 		w.WriteHeader(res.Status)
 	}
+}
+
+// logUnknownRoute logs the body POSTed to a nonexistent route (behind the
+// global token when one is set; pre-verify by definition, hence opt-in).
+func (s *Server) logUnknownRoute(w http.ResponseWriter, r *http.Request) {
+	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, s.cfg.MaxBodyBytes))
+	if err != nil || len(raw) == 0 {
+		return
+	}
+	var body any = string(raw)
+	if pl, _, err := relay.DecodeBody(r.Header.Get("Content-Type"), raw); err == nil {
+		body = pl
+	}
+	s.log.Info("payload for unknown route", "route", r.PathValue("route"), "payload", body)
 }
 
 // resultLabel renders a relay outcome for the X-Chaski-Result header, appending

--- a/internal/server/payloadlog_test.go
+++ b/internal/server/payloadlog_test.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/home-operations/chaski/internal/config"
+	"github.com/home-operations/chaski/internal/relay"
+)
+
+const payloadLogYAML = `
+targets: { po: { apprise: { url: 'pover://u@t/' } } }
+routes:
+  tapped:
+    target: po
+    whenExpr: 'payload.status == "firing"'
+    message: 'alert: {{ .payload.status }}'
+    logPayload: true
+  quiet:
+    target: po
+    message: 'x'
+`
+
+func payloadLogServer(t *testing.T, logUnknown bool) (*Server, *bytes.Buffer) {
+	t.Helper()
+	file := filepath.Join(t.TempDir(), "c.yaml")
+	if err := os.WriteFile(file, []byte(payloadLogYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rc, err := config.LoadRouteConfig(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, err := relay.Build(rc, &config.Config{RetryAttempts: 1, RetryBackoff: time.Millisecond}, relay.Options{Notifier: &fakeNotifier{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	srv := &Server{
+		cfg: &config.Config{
+			DisableRequestLogs: true,
+			MaxBodyBytes:       1 << 20,
+			RequestTimeout:     5 * time.Second,
+			LogUnknownRoutes:   logUnknown,
+		},
+		engine: e,
+		log:    slog.New(slog.NewJSONHandler(&buf, nil)),
+	}
+	return srv, &buf
+}
+
+func TestLogPayloadRoute(t *testing.T) {
+	srv, buf := payloadLogServer(t, false)
+
+	// Gate miss still logs — that is when the payload is needed most.
+	do(srv, http.MethodPost, "/hooks/tapped", `{"status":"resolved"}`, map[string]string{"Content-Type": jsonCT})
+	if !strings.Contains(buf.String(), `"payload":{"status":"resolved"}`) {
+		t.Errorf("gate miss did not log the payload:\n%s", buf.String())
+	}
+
+	buf.Reset()
+	do(srv, http.MethodPost, "/hooks/tapped", `{"status":"firing"}`, map[string]string{"Content-Type": jsonCT})
+	if !strings.Contains(buf.String(), `"payload":{"status":"firing"}`) {
+		t.Errorf("fired request did not log the payload:\n%s", buf.String())
+	}
+}
+
+func TestLogPayloadOffByDefault(t *testing.T) {
+	srv, buf := payloadLogServer(t, false)
+	do(srv, http.MethodPost, "/hooks/quiet", `{"status":"firing"}`, map[string]string{"Content-Type": jsonCT})
+	if strings.Contains(buf.String(), "inbound payload") {
+		t.Errorf("route without logPayload logged a payload:\n%s", buf.String())
+	}
+}
+
+func TestLogUnknownRoutes(t *testing.T) {
+	srv, buf := payloadLogServer(t, true)
+	rec := do(srv, http.MethodPost, "/hooks/ghost", `{"eventType":"Download"}`, map[string]string{"Content-Type": jsonCT})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 unchanged", rec.Code)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "unknown route") || !strings.Contains(out, `"payload":{"eventType":"Download"}`) {
+		t.Errorf("unknown-route payload not logged:\n%s", out)
+	}
+
+	srv, buf = payloadLogServer(t, false)
+	do(srv, http.MethodPost, "/hooks/ghost", `{"eventType":"Download"}`, map[string]string{"Content-Type": jsonCT})
+	if strings.Contains(buf.String(), "unknown route") {
+		t.Errorf("unknown-route logging fired while disabled:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
## What

Payload capture for building routes — answers "what JSON does this sender actually post?" without leaving `kubectl logs`:

1. **Per-route `logPayload: true`** — logs each inbound body for that route as a nested JSON field. Placement is deliberate: **post-verify** (an unauthenticated sender can't spray bodies into logs on a protected route) and **pre-gate** (a `whenExpr` miss still logs — exactly when the payload is needed to see which field the expression got wrong).
2. **`CHASKI_LOG_UNKNOWN_ROUTES=true`** — logs bodies POSTed to `/hooks/{route}` paths that don't exist (response stays 404). This is the discovery case: point the sender at its final URL before writing the route, press its test button, read the payload. Sits behind the global bearer token when one is set; scoped to hook paths only, bounded by `CHASKI_MAX_BODY_BYTES`.

Both default off — webhook bodies can carry secrets; the README says to enable deliberately and turn off when done. Captured payloads feed the existing loop:

```sh
kubectl logs deploy/chaski | jq 'select(.route == "alertmanager") | .payload' > sample.json
chaski validate --payload sample.json --route alertmanager
chaski send --payload sample.json --route alertmanager
```

Chart: new `config.logUnknownRoutes` value (default false) wired to the env var, with the chart README/schema regenerated — matching the chart's explicit-value-per-CHASKI_-env convention. The app README env table and config schema are regenerated too.

## Verified

Tests: logPayload logs on both gate-miss and fired requests, routes without the flag stay quiet, unknown-route logging respects the toggle and keeps the 404. `mise run test`, `lint`, `generate-check` green.
