### PR TITLE
feat!: serve health on the main port; metrics port becomes fully optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,8 @@ from the environment:
 | `CHASKI_REQUEST_TIMEOUT`        | `15s`                 | Whole-request deadline (overridden per target `timeout`) |
 | `CHASKI_RETRY_ATTEMPTS`         | `3`                   | Default per-target retry attempts (target `retry` wins)  |
 | `CHASKI_RETRY_BACKOFF`          | `200ms`               | Default retry backoff (overridden per target `retry`)    |
-| `CHASKI_METRICS_ENABLED`        | `true`                | Serve `/metrics` + `/healthz` on the metrics port        |
-| `CHASKI_METRICS_PORT`           | `8081`                | Metrics + health listener                                |
+| `CHASKI_METRICS_ENABLED`        | `true`                | Serve Prometheus `/metrics`; off ⇒ no metrics listener   |
+| `CHASKI_METRICS_PORT`           | `8081`                | Metrics listen port (`/metrics` only)                    |
 | `CHASKI_LOG_LEVEL`              | `info`                | `debug` \| `info` \| `warn` \| `error`                   |
 | `CHASKI_LOG_FORMAT`             | `json`                | slog handler: `json` or `text`                           |
 | `CHASKI_DISABLE_REQUEST_LOGS`   | `false`               | Silence the per-request access log                       |
@@ -400,10 +400,11 @@ from the environment:
 
 A JSON Schema for the route config is published at
 [`config.schema.json`](config.schema.json) — point your editor's YAML language
-server at it for completion and validation. The metrics port serves
-`GET /metrics` (Prometheus) and `GET /healthz`; requests to these
-monitoring endpoints are logged at `debug`, so scrapes and probes don't fill the
-`info` access log (set `CHASKI_LOG_LEVEL=debug` to see them).
+server at it for completion and validation. `GET /healthz` (liveness) and
+`GET /readyz` (readiness) are served on the main webhook port, and Prometheus
+`GET /metrics` on its own optional port; requests to these monitoring endpoints
+are logged at `debug`, so scrapes and probes don't fill the `info` access log
+(set `CHASKI_LOG_LEVEL=debug` to see them).
 
 Key metrics:
 

--- a/charts/chaski/README.md
+++ b/charts/chaski/README.md
@@ -78,8 +78,8 @@ Kubernetes: `>=1.25.0-0`
 | config.logLevel | string | `"info"` | Log level (CHASKI_LOG_LEVEL): debug, info, warn, or error. |
 | config.logUnknownRoutes | bool | `false` | Log bodies POSTed to nonexistent routes, still answering 404 (CHASKI_LOG_UNKNOWN_ROUTES) — payload discovery before a route exists. Pre-verify bodies; enable deliberately, turn off when done. |
 | config.maxBodyBytes | int | `1048576` | Inbound body cap in bytes (CHASKI_MAX_BODY_BYTES). |
-| config.metricsEnabled | bool | `true` | Expose Prometheus metrics + the /healthz probe on `metricsPort` (CHASKI_METRICS_ENABLED). |
-| config.metricsPort | int | `8081` | Metrics + health port (CHASKI_METRICS_PORT); kept off the public webhook port. |
+| config.metricsEnabled | bool | `true` | Expose Prometheus metrics at /metrics on metricsPort (CHASKI_METRICS_ENABLED). Disabling removes the metrics listener, container port, Service port, and ServiceMonitor entirely; health probes are unaffected (they target the http port). |
+| config.metricsPort | int | `8081` | Metrics listen port (CHASKI_METRICS_PORT), kept off the public webhook port. |
 | config.mountPath | string | `"/config"` | Where the config ConfigMap is mounted. |
 | config.port | int | `8080` | Webhook receiver port (CHASKI_PORT); also the container/Service http port. |
 | config.requestTimeout | string | `"15s"` | Whole-request deadline (CHASKI_REQUEST_TIMEOUT): decode + gate + render + send + retry. |
@@ -104,7 +104,7 @@ Kubernetes: `>=1.25.0-0`
 | image.tag | string | `""` | Overrides the image tag; defaults to the chart appVersion. |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries. |
 | initContainers | list | `[]` | Additional init containers (templated). A `chaski validate` init container against the mounted config is a good CI/rollout gate. |
-| livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"metrics"},"periodSeconds":20}` | Liveness probe. |
+| livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"http"},"periodSeconds":20}` | Liveness probe. Targets /healthz on the main http port. |
 | monitoring.serviceMonitor.annotations | object | `{}` | ServiceMonitor annotations. |
 | monitoring.serviceMonitor.enabled | bool | `false` | Create a Prometheus Operator ServiceMonitor (requires its CRDs and `config.metricsEnabled`). |
 | monitoring.serviceMonitor.interval | string | `"30s"` | Scrape interval. |
@@ -122,7 +122,7 @@ Kubernetes: `>=1.25.0-0`
 | podLabels | object | `{}` | Labels added to the pod. |
 | podSecurityContext | object | `{"fsGroup":65532,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level securityContext. chaski runs as the image's nonroot user (uid 65532); no host or elevated access is needed. |
 | priorityClassName | string | `""` | PriorityClass for the pod (templated); empty uses the cluster default. |
-| readinessProbe | object | `{"httpGet":{"path":"/healthz","port":"metrics"},"periodSeconds":10}` | Readiness probe. |
+| readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"http"},"periodSeconds":10}` | Readiness probe. Targets /readyz on the main http port. |
 | replicaCount | int | `1` | Number of replicas. chaski is stateless, so >1 is just more capacity/HA. |
 | resources | object | `{}` | Container resource requests/limits. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true}` | Container securityContext. Drops all capabilities, read-only root filesystem, no privilege escalation. |
@@ -134,7 +134,7 @@ Kubernetes: `>=1.25.0-0`
 | serviceAccount.automount | bool | `false` | Mount the API token. chaski never calls the Kubernetes API, so this is off by default. |
 | serviceAccount.create | bool | `true` | Create a ServiceAccount. |
 | serviceAccount.name | string | `""` | ServiceAccount name; empty uses the chart fullname. |
-| startupProbe | object | `{"failureThreshold":30,"httpGet":{"path":"/healthz","port":"metrics"},"periodSeconds":2}` | Startup probe (GET /healthz on the metrics port). |
+| startupProbe | object | `{"failureThreshold":30,"httpGet":{"path":"/healthz","port":"http"},"periodSeconds":2}` | Startup probe (GET /healthz on the main http port, so it works regardless of the metrics toggle). |
 | strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` | Deployment update strategy. RollingUpdate by default; chaski is stateless so a surge-then-drain rollout is safe. |
 | terminationGracePeriodSeconds | int | `30` | Grace period for a clean shutdown (drain). |
 | tests.image.pullPolicy | string | `"IfNotPresent"` | `helm test` image pull policy. |

--- a/charts/chaski/templates/deployment.tpl
+++ b/charts/chaski/templates/deployment.tpl
@@ -121,11 +121,11 @@ spec:
             - name: http
               containerPort: {{ .Values.config.port }}
               protocol: TCP
-            # Always exposed: this port serves /healthz (the probes) even when
-            # metrics are disabled; /metrics is served here only when metricsEnabled.
+            {{- if .Values.config.metricsEnabled }}
             - name: metrics
               containerPort: {{ .Values.config.metricsPort }}
               protocol: TCP
+            {{- end }}
             {{- if .Values.config.smtpEnabled }}
             - name: smtp
               containerPort: {{ .Values.config.smtpPort }}

--- a/charts/chaski/templates/tests/test-connection.tpl
+++ b/charts/chaski/templates/tests/test-connection.tpl
@@ -23,7 +23,7 @@ spec:
         - -c
         - |
           set -eu
-          url="http://{{ include "chaski.fullname" . }}:{{ .Values.config.metricsPort }}/healthz"
+          url="http://{{ include "chaski.fullname" . }}:{{ .Values.service.port }}/readyz"
           echo "GET ${url}"
           body="$(curl -fsS "${url}")"
           echo "${body}"

--- a/charts/chaski/tests/deployment_test.yaml
+++ b/charts/chaski/tests/deployment_test.yaml
@@ -110,3 +110,33 @@ tests:
             name: smtp
             containerPort: 8025
             protocol: TCP
+
+  # Pins the port standard: probes target /healthz and /readyz on the http
+  # port, and disabling metrics removes the metrics containerPort without
+  # touching them — the pod stays Ready.
+  - it: targets health probes at the http port and survives metrics-off
+    template: deployment.tpl
+    set:
+      config.metricsEnabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: metrics
+            containerPort: 8081
+            protocol: TCP
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.port
+          value: http

--- a/charts/chaski/values.schema.json
+++ b/charts/chaski/values.schema.json
@@ -80,13 +80,13 @@
         },
         "metricsEnabled": {
           "default": true,
-          "description": "Expose Prometheus metrics + the /healthz probe on `metricsPort` (CHASKI_METRICS_ENABLED).",
+          "description": "Expose Prometheus metrics at /metrics on metricsPort (CHASKI_METRICS_ENABLED). Disabling removes the metrics listener, container port, Service port, and ServiceMonitor entirely; health probes are unaffected (they target the http port).",
           "title": "metricsEnabled",
           "type": "boolean"
         },
         "metricsPort": {
           "default": 8081,
-          "description": "Metrics + health port (CHASKI_METRICS_PORT); kept off the public webhook port.",
+          "description": "Metrics listen port (CHASKI_METRICS_PORT), kept off the public webhook port.",
           "title": "metricsPort",
           "type": "integer"
         },
@@ -261,7 +261,7 @@
       "type": "array"
     },
     "livenessProbe": {
-      "description": "Liveness probe.",
+      "description": "Liveness probe. Targets /healthz on the main http port.",
       "properties": {
         "httpGet": {
           "properties": {
@@ -271,7 +271,7 @@
               "type": "string"
             },
             "port": {
-              "default": "metrics",
+              "default": "http",
               "title": "port",
               "type": "string"
             }
@@ -452,17 +452,17 @@
       "type": "string"
     },
     "readinessProbe": {
-      "description": "Readiness probe.",
+      "description": "Readiness probe. Targets /readyz on the main http port.",
       "properties": {
         "httpGet": {
           "properties": {
             "path": {
-              "default": "/healthz",
+              "default": "/readyz",
               "title": "path",
               "type": "string"
             },
             "port": {
-              "default": "metrics",
+              "default": "http",
               "title": "port",
               "type": "string"
             }
@@ -598,7 +598,7 @@
       "type": "object"
     },
     "startupProbe": {
-      "description": "Startup probe (GET /healthz on the metrics port).",
+      "description": "Startup probe (GET /healthz on the main http port, so it works regardless of the metrics toggle).",
       "properties": {
         "failureThreshold": {
           "default": 30,
@@ -613,7 +613,7 @@
               "type": "string"
             },
             "port": {
-              "default": "metrics",
+              "default": "http",
               "title": "port",
               "type": "string"
             }

--- a/charts/chaski/values.yaml
+++ b/charts/chaski/values.yaml
@@ -37,9 +37,9 @@ replicaCount: 1
 config:
   # -- Webhook receiver port (CHASKI_PORT); also the container/Service http port.
   port: 8080
-  # -- Expose Prometheus metrics + the /healthz probe on `metricsPort` (CHASKI_METRICS_ENABLED).
+  # -- Expose Prometheus metrics at /metrics on metricsPort (CHASKI_METRICS_ENABLED). Disabling removes the metrics listener, container port, Service port, and ServiceMonitor entirely; health probes are unaffected (they target the http port).
   metricsEnabled: true
-  # -- Metrics + health port (CHASKI_METRICS_PORT); kept off the public webhook port.
+  # -- Metrics listen port (CHASKI_METRICS_PORT), kept off the public webhook port.
   metricsPort: 8081
   # -- Log level (CHASKI_LOG_LEVEL): debug, info, warn, or error.
   logLevel: info
@@ -146,24 +146,24 @@ securityContext:
     drop:
       - ALL
 
-# -- Startup probe (GET /healthz on the metrics port).
+# -- Startup probe (GET /healthz on the main http port, so it works regardless of the metrics toggle).
 startupProbe:
   httpGet:
     path: /healthz
-    port: metrics
+    port: http
   failureThreshold: 30
   periodSeconds: 2
-# -- Liveness probe.
+# -- Liveness probe. Targets /healthz on the main http port.
 livenessProbe:
   httpGet:
     path: /healthz
-    port: metrics
+    port: http
   periodSeconds: 20
-# -- Readiness probe.
+# -- Readiness probe. Targets /readyz on the main http port.
 readinessProbe:
   httpGet:
-    path: /healthz
-    port: metrics
+    path: /readyz
+    port: http
   periodSeconds: 10
 
 # -- Container resource requests/limits.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,10 +23,13 @@ type Config struct {
 	// HTTPPort is the public webhook receiver (POST /hooks/{route}).
 	HTTPPort int `env:"CHASKI_PORT" envDefault:"8080"`
 
-	// MetricsEnabled exposes Prometheus metrics at /metrics and the /healthz
-	// probe on MetricsPort, keeping monitoring off the public webhook port.
+	// MetricsEnabled exposes Prometheus metrics at /metrics on MetricsPort.
+	// Disabling it removes the metrics listener entirely; the /healthz and
+	// /readyz probe endpoints live on the main webhook port and are unaffected.
 	MetricsEnabled bool `env:"CHASKI_METRICS_ENABLED" envDefault:"true"`
-	MetricsPort    int  `env:"CHASKI_METRICS_PORT" envDefault:"8081"`
+	// MetricsPort is bound as ":<port>" (unspecified address), so it serves
+	// IPv4-only, IPv6-only, and dual-stack clusters alike.
+	MetricsPort int `env:"CHASKI_METRICS_PORT" envDefault:"8081"`
 
 	// ConfigPath is the routes + targets source: a single YAML file or a
 	// directory of *.yaml/*.yml fragments merged additively (config.d).

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -21,6 +21,12 @@ func (s *Server) handler() http.Handler {
 	// Registered method-agnostic (not "POST /hooks/{route}") so a non-POST gets
 	// an explicit 405 rather than being swallowed by the "/" catch-all's 404.
 	mux.HandleFunc("/hooks/{route}", s.handleHook)
+	// The org pair standard: /healthz = liveness (cheap, no dependencies),
+	// /readyz = readiness, both on the main port so the optional metrics
+	// listener can be disabled without touching the probes. chaski has no
+	// serving condition beyond being up, so readyz aliases healthz.
+	mux.HandleFunc("GET /healthz", handleHealth)
+	mux.HandleFunc("GET /readyz", handleHealth)
 	mux.HandleFunc("/", handleNotFound)
 
 	var h http.Handler = mux

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -61,17 +61,13 @@ func (s *Server) observeRelay(route string, res relay.Result) {
 	}
 }
 
-// metricsHandler serves Prometheus metrics and the health/readiness probe on
-// the dedicated monitoring listener, so scraping and probing share one port
-// (8081 by default) separate from the public webhook port.
-func metricsHandler(metricsEnabled bool) http.Handler {
+// metricsHandler serves Prometheus metrics on the dedicated, optional metrics
+// listener (8081 by default), kept off the public webhook port. Health probes
+// are NOT served here — /healthz and /readyz live on the webhook listener, so
+// this whole port can be disabled without breaking probes.
+func metricsHandler() http.Handler {
 	mux := http.NewServeMux()
-	// /healthz is always served: the liveness/readiness probe must work even when
-	// Prometheus metrics are disabled, so the pod can still become Ready.
-	mux.HandleFunc("GET /healthz", handleHealth)
-	if metricsEnabled {
-		mux.Handle("GET /metrics", promhttp.Handler())
-	}
+	mux.Handle("GET /metrics", promhttp.Handler())
 	return mux
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -57,11 +57,14 @@ func (s *Server) Run(ctx context.Context) error {
 	webhookSrv := newHTTPServer(fmt.Sprintf(":%d", s.cfg.HTTPPort), s.handler())
 	g.Go(func() error { return serve(webhookSrv, "webhook", s.log) })
 
-	// The monitoring listener always runs: it serves /healthz (liveness/readiness)
-	// regardless of whether Prometheus /metrics is enabled, so disabling metrics
-	// can't leave the pod without a health endpoint. MetricsEnabled gates /metrics.
-	monitoringSrv := newHTTPServer(fmt.Sprintf(":%d", s.cfg.MetricsPort), s.accessLog(metricsHandler(s.cfg.MetricsEnabled)))
-	g.Go(func() error { return serve(monitoringSrv, "monitoring", s.log) })
+	// The metrics listener is metrics-only and fully optional: /healthz and
+	// /readyz live on the webhook listener above, so disabling metrics removes
+	// this port without touching the probes.
+	var metricsSrv *http.Server
+	if s.cfg.MetricsEnabled {
+		metricsSrv = newHTTPServer(fmt.Sprintf(":%d", s.cfg.MetricsPort), s.accessLog(metricsHandler()))
+		g.Go(func() error { return serve(metricsSrv, "metrics", s.log) })
+	}
 
 	var smtpSrv *smtp.Server
 	if s.cfg.SMTPEnabled {
@@ -75,7 +78,7 @@ func (s *Server) Run(ctx context.Context) error {
 		sctx, cancel := context.WithTimeout(context.Background(), s.cfg.ShutdownTimeout)
 		defer cancel()
 		shutdown(sctx, webhookSrv)
-		shutdown(sctx, monitoringSrv)
+		shutdown(sctx, metricsSrv)
 		smtpSrv.Shutdown(sctx)
 		return nil
 	})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -133,26 +133,32 @@ func TestRequestLogLevels(t *testing.T) {
 	}
 }
 
-func TestHealthzServedEvenWhenMetricsDisabled(t *testing.T) {
+// Health lives on the main webhook listener (the chart's probes target the
+// http port), NOT the optional metrics listener — so disabling metrics can
+// never break the probes. /readyz aliases /healthz (the pair standard).
+func TestHealthOnMainPortNotMetricsPort(t *testing.T) {
+	srv := newServer(emptyEngine(t), "")
+	for _, path := range []string{"/healthz", "/readyz"} {
+		rec := httptest.NewRecorder()
+		srv.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"status":"ok"`) {
+			t.Fatalf("main handler %s: %d %q", path, rec.Code, rec.Body.String())
+		}
+	}
+
+	// The metrics handler is metrics-only.
 	rec := httptest.NewRecorder()
-	// metrics off: /healthz must still work, so probes keep the pod Ready.
-	metricsHandler(false).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
-	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"status":"ok"`) {
-		t.Fatalf("healthz: %d %q", rec.Code, rec.Body.String())
+	metricsHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("metrics handler /healthz status = %d, want 404 (metrics-only listener)", rec.Code)
 	}
 }
 
 func TestMetricsEndpoint(t *testing.T) {
 	rec := httptest.NewRecorder()
-	metricsHandler(true).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	metricsHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("metrics status = %d", rec.Code)
-	}
-	// metrics off: /metrics is not registered (404).
-	rec = httptest.NewRecorder()
-	metricsHandler(false).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("metrics disabled: status = %d, want 404", rec.Code)
 	}
 }
 


### PR DESCRIPTION
Rollout PR #2 of the org metrics/health standard (primary-HTTP tier + the `/healthz`+`/readyz` pair).

## What changed

- **`/healthz` (liveness) + `/readyz` (readiness) on the main webhook port (8080).** readyz aliases healthz today — the endpoint exists so probes and external configs never change if chaski ever gains a real serving condition. (This also retires the long-standing wart of `/readyz` appearing in the debug-log path map without being served.)
- **Probes target the `http` port** (liveness+startup → `/healthz`, readiness → `/readyz`). New chart test pins that `metricsEnabled: false` removes the metrics containerPort while probes still resolve.
- **Metrics listener is metrics-only and truly optional** — disabling removes the listener, container port, Service port, and ServiceMonitor. This supersedes the interim #38 shape (always-on monitoring listener serving health): health now rides the always-present main port, so there's no orphan 8081 when metrics are off.
- **helm test hook** now checks `/readyz` on the Service http port instead of `metricsPort/healthz`.
- `CHASKI_METRICS_PORT` stays a port int bound `":<port>"` (already dual-stack safe).

## Compatibility

- In-chart consumers (probes, ServiceMonitor) updated automatically.
- **External** probe/scrape configs pointing at `:8081/healthz` must move to the http port — hence `feat!`.

`go test -race` green, lint 0 issues, `helm lint` + `helm unittest` (20/20) green, docs/schema regenerated, `helm template --set config.metricsEnabled=false` renders no metrics port and http-targeted probes.

Prior PR in the rollout: home-operations/echo#28. Next: kromgo, konflate, then tuppr/litellm-operator/miroir, then drm-exporter.
