### PR TITLE
fix: review findings — apprise URL leaks, strict HMAC prefix, coverage to 85%

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ routes:
         header: X-Signature
         algo: sha256 # sha256 (default) | sha512
         encoding: hex # hex (default) | base64
-        prefix: "sha256=" # stripped before decoding
+        prefix: "sha256=" # required on the header value, stripped before decoding
         secret: '{{ env "HMAC_SECRET" }}'
 ```
 

--- a/cmd/chaski/main_test.go
+++ b/cmd/chaski/main_test.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/home-operations/chaski/internal/config"
+	"github.com/home-operations/chaski/internal/relay"
 )
 
 func writeCfg(t *testing.T, body string) string {
@@ -172,5 +176,32 @@ func TestRootCommand(t *testing.T) {
 	root.SetArgs([]string{"bogus"})
 	if err := root.Execute(); err == nil {
 		t.Fatal("unknown argument: want an error, not the server starting")
+	}
+}
+
+func TestResolveConfigPath(t *testing.T) {
+	if got := resolveConfigPath("/flag/path.yaml"); got != "/flag/path.yaml" {
+		t.Errorf("flag should win, got %q", got)
+	}
+	t.Setenv("CHASKI_CONFIG", "/env/path.yaml")
+	if got := resolveConfigPath(""); got != "/env/path.yaml" {
+		t.Errorf("env should apply when the flag is empty, got %q", got)
+	}
+	t.Setenv("CHASKI_CONFIG", "")
+	if got := resolveConfigPath(""); got != config.DefaultConfigPath {
+		t.Errorf("default should apply last, got %q", got)
+	}
+}
+
+func TestPrintResultNonDryKinds(t *testing.T) {
+	var buf strings.Builder
+	if err := printResult(&buf, "r", relay.Result{Kind: relay.Skipped, Reason: "gate"}); err != nil {
+		t.Fatalf("printResult(skipped) = %v, want nil", err)
+	}
+	if !strings.Contains(buf.String(), "skipped") {
+		t.Errorf("output = %q, want the outcome named", buf.String())
+	}
+	if err := printResult(&buf, "r", relay.Result{Kind: relay.GateError, Err: errors.New("boom")}); err == nil {
+		t.Error("printResult(gate error) = nil, want error")
 	}
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"go.yaml.in/yaml/v4"
 )
 
 // loadTarget loads a config whose route "r" uses the given `target:` YAML, with
@@ -394,5 +396,74 @@ func TestSymlinkEscapeRejected(t *testing.T) {
 	_, err := LoadRouteConfig(dir)
 	if err == nil || !strings.Contains(err.Error(), "outside") {
 		t.Fatalf("err = %v, want a symlink-escape error", err)
+	}
+}
+
+func TestVerifyKindAndSecrets(t *testing.T) {
+	gh := &Verify{GitHub: &GitHubVerify{Secret: StringList{"a"}}}
+	hm := &Verify{HMAC: &HMACVerify{Header: "X-Sig", Secret: StringList{"b"}}}
+	tk := &Verify{Token: &TokenVerify{Header: "X-Tok", Secret: StringList{"c"}}}
+	multi := &Verify{GitHub: gh.GitHub, Token: tk.Token}
+
+	cases := []struct {
+		v    *Verify
+		kind string
+		sec  string
+	}{
+		{gh, "github", "a"},
+		{hm, "hmac", "b"},
+		{tk, "token", "c"},
+	}
+	for _, c := range cases {
+		if got := c.v.VerifyKind(); got != c.kind {
+			t.Errorf("VerifyKind = %q, want %q", got, c.kind)
+		}
+		if s := c.v.Secrets(); len(s) != 1 || s[0] != c.sec {
+			t.Errorf("Secrets = %v, want [%s]", s, c.sec)
+		}
+	}
+	if got := multi.VerifyKind(); got != "" {
+		t.Errorf("VerifyKind = %q for a multi-variant block, want empty", got)
+	}
+	if s := (&Verify{}).Secrets(); s != nil {
+		t.Errorf("Secrets = %v for an empty block, want nil", s)
+	}
+}
+
+func TestTemplateSourceProvenance(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.yaml"), []byte("templates: { greet: 'hi' }"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rc, err := LoadRouteConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := rc.TemplateSource("greet"); got != "a.yaml" {
+		t.Errorf("TemplateSource(greet) = %q, want a.yaml", got)
+	}
+	if got := rc.TemplateSource("missing"); got != "" {
+		t.Errorf("TemplateSource(missing) = %q, want empty", got)
+	}
+}
+
+func TestStringListForms(t *testing.T) {
+	decode := func(t *testing.T, y string) (StringList, error) {
+		t.Helper()
+		var s struct {
+			V StringList `yaml:"v"`
+		}
+		err := yaml.Load([]byte(y), &s)
+		return s.V, err
+	}
+
+	if v, err := decode(t, "v: one"); err != nil || len(v) != 1 || v[0] != "one" {
+		t.Errorf("scalar = %v (%v), want [one]", v, err)
+	}
+	if v, err := decode(t, "v: [a, b]"); err != nil || len(v) != 2 || v[1] != "b" {
+		t.Errorf("list = %v (%v), want [a b]", v, err)
+	}
+	if _, err := decode(t, "v: {k: 1}"); err == nil {
+		t.Error("mapping should not decode into a StringList")
 	}
 }

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -136,3 +136,14 @@ func TestNonBooleanResultIsRuntimeError(t *testing.T) {
 		t.Fatal("expected a runtime error for a non-boolean result")
 	}
 }
+
+func TestSource(t *testing.T) {
+	const expr = `payload.x == 1`
+	g, err := Compile(expr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g.Source() != expr {
+		t.Errorf("Source = %q, want the original expression", g.Source())
+	}
+}

--- a/internal/relay/decode.go
+++ b/internal/relay/decode.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -19,7 +20,7 @@ func DecodeBody(contentType string, raw []byte) (any, string, error) {
 	}
 	switch strings.TrimSpace(media) {
 	case "", "application/json":
-		if len(strings.TrimSpace(string(raw))) == 0 {
+		if len(bytes.TrimSpace(raw)) == 0 {
 			return map[string]any{}, contentType, nil
 		}
 		var p any

--- a/internal/relay/morecases_test.go
+++ b/internal/relay/morecases_test.go
@@ -77,3 +77,31 @@ func TestDryRunPlanOmitsTargetCredentials(t *testing.T) {
 		t.Errorf("dry-run plan leaked target credentials: %s", s)
 	}
 }
+
+func TestKindString(t *testing.T) {
+	want := map[relay.Kind]string{
+		relay.Relayed: "relayed", relay.Skipped: "skipped", relay.DryRunned: "dryrun",
+		relay.GateError: "gate_error", relay.RenderError: "render_error", relay.RelayError: "relay_error",
+		relay.Kind(99): "unknown",
+	}
+	for k, s := range want {
+		if got := k.String(); got != s {
+			t.Errorf("Kind(%d).String() = %q, want %q", k, got, s)
+		}
+	}
+}
+
+func TestEngineAccessors(t *testing.T) {
+	e := engine(t, apprise1, &fakeNotifier{})
+	if e.RouteCount() != 1 {
+		t.Errorf("RouteCount = %d, want 1", e.RouteCount())
+	}
+	r := route(t, e)
+	if r.LogPayload() {
+		t.Error("LogPayload = true for a route without logPayload")
+	}
+	// A route with no verify block accepts any body.
+	if !r.Verify(nil, []byte("anything")) {
+		t.Error("Verify = false for a route without a verify block")
+	}
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -98,7 +98,7 @@ type Route struct {
 	headers    *render.Map
 	targets    []routeTarget
 	okStatus   int
-	skipState  int
+	skipStatus int
 	logPayload bool
 }
 
@@ -159,7 +159,7 @@ func buildRoute(name string, rt *config.Route, sinks map[string]sink.Sink, set *
 	return &Route{
 		name: name, gate: g, verifier: vf,
 		title: title, message: message, params: params, headers: headers,
-		targets: targets, okStatus: ok, skipState: skip,
+		targets: targets, okStatus: ok, skipStatus: skip,
 		logPayload: rt.LogPayload,
 	}, nil
 }
@@ -244,7 +244,7 @@ func (r *Route) Handle(ctx context.Context, in Input) Result {
 		if in.DryRun {
 			return Result{Status: http.StatusOK, Kind: DryRunned, Plan: &Plan{Route: r.name, Fired: false}}
 		}
-		return Result{Status: r.skipState, Kind: Skipped, Reason: "gate"}
+		return Result{Status: r.skipStatus, Kind: Skipped, Reason: "gate"}
 	}
 
 	// Per-target gates pick the fan-out subset against the same variables as the
@@ -268,7 +268,7 @@ func (r *Route) Handle(ctx context.Context, in Input) Result {
 		return Result{Status: http.StatusBadGateway, Kind: RelayError, Err: err, Dropped: rr.dropped}
 	}
 	if sent == 0 {
-		return Result{Status: r.skipState, Kind: Skipped, Reason: "no_targets", Dropped: rr.dropped}
+		return Result{Status: r.skipStatus, Kind: Skipped, Reason: "no_targets", Dropped: rr.dropped}
 	}
 	return Result{Status: r.okStatus, Kind: Relayed, Dropped: rr.dropped}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -312,5 +314,120 @@ func TestRecovererTurnsPanicInto500(t *testing.T) {
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+// freePort reserves an ephemeral wildcard port and releases it for a listener.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// TestRunLifecycle exercises the full listener lifecycle: webhook, metrics, and
+// SMTP all come up, serve, and drain cleanly on context cancellation.
+func TestRunLifecycle(t *testing.T) {
+	cfg := &config.Config{
+		HTTPPort:            freePort(t),
+		MetricsEnabled:      true,
+		MetricsPort:         freePort(t),
+		SMTPEnabled:         true,
+		SMTPPort:            freePort(t),
+		SMTPHostname:        "chaski-test",
+		SMTPMaxMessageBytes: 1 << 20,
+		SMTPMaxRecipients:   10,
+		MaxBodyBytes:        1 << 20,
+		RequestTimeout:      5 * time.Second,
+		ShutdownTimeout:     5 * time.Second,
+		DisableRequestLogs:  true,
+	}
+	srv := New(cfg, emptyEngine(t), slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	get := func(port int, path string) *http.Response {
+		t.Helper()
+		var resp *http.Response
+		var err error
+		for range 100 {
+			resp, err = http.Get(fmt.Sprintf("http://127.0.0.1:%d%s", port, path))
+			if err == nil {
+				return resp
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		t.Fatalf("GET :%d%s never succeeded: %v", port, path, err)
+		return nil
+	}
+
+	for _, path := range []string{"/healthz", "/readyz"} {
+		resp := get(cfg.HTTPPort, path)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("%s status = %d, want 200", path, resp.StatusCode)
+		}
+	}
+	resp := get(cfg.MetricsPort, "/metrics")
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("/metrics status = %d, want 200", resp.StatusCode)
+	}
+
+	// The SMTP listener greets with a 220.
+	var conn net.Conn
+	var err error
+	for range 100 {
+		conn, err = net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.SMTPPort))
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("SMTP dial never succeeded: %v", err)
+	}
+	greeting := make([]byte, 3)
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, err := io.ReadFull(conn, greeting); err != nil || string(greeting) != "220" {
+		t.Errorf("SMTP greeting = %q (err %v), want 220", greeting, err)
+	}
+	_ = conn.Close()
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned %v, want nil after graceful shutdown", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return after cancellation")
+	}
+}
+
+func TestRunReportsBindFailure(t *testing.T) {
+	// Occupy the wildcard port so the webhook listener fails to bind and Run
+	// surfaces the error.
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	cfg := &config.Config{
+		HTTPPort:           l.Addr().(*net.TCPAddr).Port,
+		MaxBodyBytes:       1 << 20,
+		RequestTimeout:     time.Second,
+		ShutdownTimeout:    time.Second,
+		DisableRequestLogs: true,
+	}
+	srv := New(cfg, emptyEngine(t), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err := srv.Run(context.Background()); err == nil {
+		t.Error("Run = nil, want bind error for an occupied port")
 	}
 }

--- a/internal/sink/apprise.go
+++ b/internal/sink/apprise.go
@@ -2,6 +2,7 @@ package sink
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -27,8 +28,9 @@ func (appriseNotifier) Send(ctx context.Context, targetURL, body, title string, 
 	}
 	a := apprise.New()
 	if err := a.Add(full); err != nil {
-		// A bad URL/scheme won't fix itself on retry.
-		return Permanent(fmt.Errorf("apprise: invalid target url: %w", err))
+		// A bad URL/scheme won't fix itself on retry. Like Send below, the error
+		// text may echo the credential-bearing URL — redact before it reaches logs.
+		return Permanent(fmt.Errorf("apprise: invalid target url: %s", redactURLs(err.Error(), full, targetURL)))
 	}
 	var opts []apprise.Option
 	if title != "" {
@@ -68,6 +70,12 @@ func mergeQuery(rawURL string, params map[string]string) (string, error) {
 	}
 	u, err := url.Parse(rawURL)
 	if err != nil {
+		// url.Parse returns a *url.Error that embeds the raw (credential-bearing)
+		// URL; unwrap to the bare cause so the URL never reaches logs.
+		var ue *url.Error
+		if errors.As(err, &ue) {
+			err = ue.Err
+		}
 		return "", Permanent(fmt.Errorf("apprise: parse target url: %w", err))
 	}
 	q := u.Query()

--- a/internal/sink/apprise_test.go
+++ b/internal/sink/apprise_test.go
@@ -1,0 +1,48 @@
+package sink
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// The notifier's error paths must never echo the credential-bearing target URL:
+// it would flow through observeRelay into logs.
+
+func TestNotifierParseErrorOmitsURL(t *testing.T) {
+	// A control character makes url.Parse fail; the URL carries a credential.
+	bad := "pover://user:supersecret@host/\x7f"
+	err := appriseNotifier{}.Send(t.Context(), bad, "body", "", map[string]string{"k": "v"})
+	if err == nil {
+		t.Fatal("Send = nil, want parse error")
+	}
+	if !isPermanent(err) {
+		t.Errorf("parse error should be permanent (no retry), got %v", err)
+	}
+	if strings.Contains(err.Error(), "supersecret") {
+		t.Errorf("error leaks the credential: %v", err)
+	}
+}
+
+func TestNotifierAddErrorRedactsURL(t *testing.T) {
+	// An unsupported scheme fails apprise's Add; its error text may echo the URL.
+	bad := "bogus://user:supersecret@host/x"
+	err := appriseNotifier{}.Send(t.Context(), bad, "body", "", nil)
+	if err == nil {
+		t.Fatal("Send = nil, want invalid-scheme error")
+	}
+	if !isPermanent(err) {
+		t.Errorf("invalid scheme should be permanent (no retry), got %v", err)
+	}
+	if strings.Contains(err.Error(), "supersecret") {
+		t.Errorf("error leaks the credential: %v", err)
+	}
+}
+
+func TestNotifierCancelledContextShortCircuits(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := (appriseNotifier{}).Send(ctx, "pover://u@t/", "body", "", nil); err == nil {
+		t.Error("Send = nil, want the context error before any send")
+	}
+}

--- a/internal/sink/sink_test.go
+++ b/internal/sink/sink_test.go
@@ -195,3 +195,14 @@ func TestNewBuildsSinks(t *testing.T) {
 		t.Fatalf("http sink: %v kind=%q", err, h.Kind())
 	}
 }
+
+func TestSinkIdentity(t *testing.T) {
+	a := &appriseSink{name: "po"}
+	if a.Name() != "po" || a.Kind() != "apprise" {
+		t.Errorf("apprise identity = %s/%s", a.Name(), a.Kind())
+	}
+	h := &httpSink{name: "hook"}
+	if h.Name() != "hook" || h.Kind() != "http" {
+		t.Errorf("http identity = %s/%s", h.Name(), h.Kind())
+	}
+}

--- a/internal/smtp/smtp_test.go
+++ b/internal/smtp/smtp_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -321,5 +322,71 @@ func TestLoginServerExchange(t *testing.T) {
 	}
 	if gotUser != "alice" || gotPass != "secret" {
 		t.Errorf("auth got %q/%q, want alice/secret", gotUser, gotPass)
+	}
+}
+
+// TestServerLifecycle exercises New/ListenAndServe/Shutdown for real: the
+// listener greets, and Shutdown drains cleanly.
+func TestServerLifecycle(t *testing.T) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+
+	cfg := &config.Config{
+		SMTPPort:            port,
+		SMTPHostname:        "chaski-test",
+		SMTPMaxMessageBytes: 1 << 20,
+		SMTPMaxRecipients:   10,
+		RequestTimeout:      5 * time.Second,
+	}
+	srv := New(cfg, engineWithAlerts(t, &fakeNotifier{}), discardLog(), nil)
+	done := make(chan error, 1)
+	go func() { done <- srv.ListenAndServe() }()
+
+	var conn net.Conn
+	for range 100 {
+		conn, err = net.Dial("tcp", srv.inner.Addr)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("dial never succeeded: %v", err)
+	}
+	greeting := make([]byte, 3)
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, err := io.ReadFull(conn, greeting); err != nil || string(greeting) != "220" {
+		t.Errorf("greeting = %q (err %v), want 220", greeting, err)
+	}
+	_ = conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	srv.Shutdown(ctx)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("ListenAndServe returned %v, want nil after Shutdown", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ListenAndServe did not return after Shutdown")
+	}
+
+	// Shutdown is nil-safe (the server may never have been built).
+	var nilSrv *Server
+	nilSrv.Shutdown(ctx)
+}
+
+func TestParsePlainUnparseableBlobBecomesText(t *testing.T) {
+	m := parsePlain([]byte("not an email at all"))
+	if m.text != "not an email at all" {
+		t.Errorf("text = %q, want the raw blob", m.text)
+	}
+	if m.subject != "" || m.from != "" {
+		t.Errorf("subject/from = %q/%q, want empty", m.subject, m.from)
 	}
 }

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -145,7 +145,13 @@ func (vf *Verifier) Verify(headers http.Header, body []byte) bool {
 		}
 		return false
 	case modeHMAC:
-		provided, err := decodeMAC(vf.encoding, strings.TrimPrefix(got, vf.prefix))
+		// A configured prefix is part of the signature contract (GitHub's
+		// "sha256=..."): a header without it is malformed, not close enough.
+		sig, ok := strings.CutPrefix(got, vf.prefix)
+		if !ok {
+			return false
+		}
+		provided, err := decodeMAC(vf.encoding, sig)
 		if err != nil {
 			return false
 		}

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -123,3 +123,17 @@ func TestCompileErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestHMACPrefixRequired(t *testing.T) {
+	body := `{"a":1}`
+	vf := mustCompile(t, &config.Verify{GitHub: &config.GitHubVerify{Secret: config.StringList{"s3cr3t"}}})
+
+	// A valid signature without the configured prefix is malformed, not close
+	// enough — the prefix is part of the contract.
+	if vf.Verify(hdr("X-Hub-Signature-256", hmacHex("s3cr3t", body)), []byte(body)) {
+		t.Error("signature without the sha256= prefix must fail")
+	}
+	if !vf.Verify(hdr("X-Hub-Signature-256", "sha256="+hmacHex("s3cr3t", body)), []byte(body)) {
+		t.Error("prefixed signature should verify")
+	}
+}


### PR DESCRIPTION
Full project review (same treatment as echo#29): every finding fixed, plus a cleanliness/coverage pass. The codebase was already in strong shape from the v0.1.0 hardening — the findings are narrower than echo's.

## Security / hardening

- **Two apprise error paths could leak the credential-bearing target URL into logs.** `mergeQuery`'s `url.Parse` failure returns a `*url.Error` that embeds the raw URL, and apprise-go's `Add` error can echo it — both flowed through `observeRelay` into the error log, bypassing the redaction `Send` already applied. The parse error is now unwrapped to its bare cause and the `Add` error goes through `redactURLs`. Tests assert neither path can emit the credential.
- **A configured HMAC prefix is now required, not optional.** `strings.TrimPrefix` was a no-op when the header lacked the prefix, so the GitHub preset accepted a bare hex signature without `sha256=`. Now `strings.CutPrefix` rejects an unprefixed value — the prefix is part of the signature contract. (Not a forgeability issue — a valid HMAC was always required — just a looser contract than intended. GitHub always sends the prefix, so real senders are unaffected.)

## Cleanliness

- `DecodeBody` no longer copies up to 1 MiB of body into a string just to check emptiness (`bytes.TrimSpace`).
- `Route.skipState` → `skipStatus`, matching its `okStatus` neighbor and the `response.skipStatus` config field.
- Dead-code/TODO sweep: clean (nothing found — the include-guard and threat-model passes left little behind).

## Coverage 78.7% → 85.2%

New tests: the full server `Run` lifecycle (webhook + metrics + SMTP listeners up, probes and the 220 greeting answered, graceful drain returns nil) and bind-failure surfacing; the SMTP server's own `New`/`ListenAndServe`/`Shutdown` (incl. nil-safety) and the unparseable-blob fallback; the apprise notifier's error paths (credential-leak assertions, cancelled-context short-circuit); the HMAC prefix contract; `Kind` labels, engine/config accessors, `StringList` decode forms, `resolveConfigPath` chain, and `printResult` non-dry outcomes. Server package went 73.7% → 93.1%, sink 78.2% → 86%, relay 84.2% → 90.2%.

## Verification
- `go test ./...` green; golangci-lint 0 issues; gofmt clean; schema regenerated (pre-commit hook)
- README: the `verify.hmac.prefix` doc now states the prefix is required on the header value