### PR TITLE
style: indent markdown at 2 to match embedded yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = false
 
 [Dockerfile]


### PR DESCRIPTION
Mirrors the canonical change in home-operations/.github#37.

chaski was missed in the first rollout batch: its README markdown was already 2-space, so a reformat produced no diff, and I wrongly read "no reformat" as "no change needed". But the editorconfig itself still said `[*.md] indent_size = 4`, so the next edit to any markdown file here would have had the pre-commit oxfmt reindent embedded yaml examples to 4 spaces, reintroducing the bug fixed across the rest of the org.

This flips `[*.md] indent_size` to 2. No files reformat (they already match); the change is the one-line config so the setting is consistent with every other repo.