### PR TITLE
fix(helm): stamp Chart.yaml version on release

### DIFF
--- a/charts/chaski/Chart.yaml
+++ b/charts/chaski/Chart.yaml
@@ -4,10 +4,11 @@ name: chaski
 description: A stateless CEL-gated webhook relay — gate any JSON with CEL, render with Go templates, relay to an apprise notification or an HTTP request
 type: application
 kubeVersion: ">=1.25.0-0"
-# version + appVersion are overridden at package time: version from the release
-# tag, appVersion from the same tag (the chart deploys chaski's own image).
-version: 0.0.0
-appVersion: "0.0.0"
+# release-please stamps both from the release tag (the release workflow also
+# passes --version/--app-version at package time); stamping the committed copy
+# keeps it from going stale.
+version: 0.3.2 # x-release-please-version
+appVersion: "0.3.2" # x-release-please-version
 home: https://github.com/home-operations/chaski
 sources:
   - https://github.com/home-operations/chaski

--- a/charts/chaski/README.md
+++ b/charts/chaski/README.md
@@ -1,6 +1,8 @@
 # chaski
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version](https://img.shields.io/static/v1?label=Version&message=0.3.2&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message=0.3.2&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 A stateless **webhook relay**: `POST` any JSON to a named route, gate it with a
 [CEL](https://github.com/google/cel-go) expression, render fields with Go

--- a/charts/chaski/README.md.gotmpl
+++ b/charts/chaski/README.md.gotmpl
@@ -2,7 +2,15 @@
 
 {{ template "chart.deprecationWarning" . }}
 
-{{ template "chart.badgesSection" . }}
+{{- /* Hand-rolled badges instead of chart.badgesSection so release-please can
+stamp the version: its updater replaces only the first semver on an annotated
+line and would swallow a `-color` suffix as a prerelease, so each version badge
+uses the static/v1 query form (version followed by `&`), keeps the version out
+of its alt text, and carries its own annotation. Keeps the committed README in
+sync with the stamped Chart.yaml. */}}
+![Version](https://img.shields.io/static/v1?label=Version&message={{ .Version }}&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: {{ .Type }}](https://img.shields.io/badge/Type-{{ .Type }}-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message={{ .AppVersion }}&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 A stateless **webhook relay**: `POST` any JSON to a named route, gate it with a
 [CEL](https://github.com/google/cel-go) expression, render fields with Go

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
-  "exclude-paths": [
-    "release-please-config.json",
-    ".release-please-manifest.json"
-  ],
+  "exclude-paths": ["release-please-config.json", ".release-please-manifest.json"],
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
@@ -14,7 +11,11 @@
       "include-component-in-tag": false,
       "include-v-in-tag": false,
       "include-v-in-release-name": false,
-      "always-update": true
+      "always-update": true,
+      "extra-files": [
+        { "type": "generic", "path": "charts/chaski/Chart.yaml" },
+        "charts/chaski/README.md"
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Ports the pattern already shipped in home-operations/tuppr#414 + home-operations/tuppr#415.

## Problem

`charts/chaski/Chart.yaml` carried a `0.0.0` placeholder for both `version` and `appVersion`. The release workflow re-stamps at package time (`helm package --version/--app-version`), so published artifacts were always correct, but the committed chart and its helm-docs-generated README advertised a version that never existed.

## Change

- `charts/chaski/Chart.yaml` — `version`/`appVersion` seeded at the currently released `0.3.2` (from `.release-please-manifest.json`) and annotated `# x-release-please-version`. The stale "overridden at package time" comment is replaced with the actual rationale.
- `release-please-config.json` — `charts/chaski/Chart.yaml` + `charts/chaski/README.md` added to `extra-files`.
- `charts/chaski/README.md.gotmpl` — hand-rolled version badges replacing `chart.badgesSection`.
- `charts/chaski/README.md` — regenerated via `mise run generate`.

### Why the typed `generic` updater

`extra-files` entries use the typed form for the YAML file:

```json
"extra-files": [
  { "type": "generic", "path": "charts/chaski/Chart.yaml" },
  "charts/chaski/README.md"
]
```

release-please infers its updater from the file extension when given a bare path string. A plain `"charts/chaski/Chart.yaml"` selects the YAML updater, which re-serializes the whole document (stripping every comment in the file) and only rewrites the `version` key, leaving `appVersion` unstamped. `{"type": "generic"}` forces the annotation-driven line updater, which edits in place and honours both annotated lines.

### Why the badges are hand-rolled

The generic updater replaces only the first semver on an annotated line, and helm-docs' default `img.shields.io/badge/Version-0.0.0-informational` form would let it swallow the `-informational` suffix as a prerelease. Each version badge now uses the `static/v1` query form so the version is terminated by `&`, keeps the version out of its alt text, and carries its own `<!-- x-release-please-version -->`. This keeps the committed README in sync with the stamped Chart.yaml; the constraint is documented in a comment in the template.

### Tests

No chart unit test asserted the placeholder version or an image tag, so no test changes were needed here (this is the one part of the tuppr pattern that does not apply — tuppr's `deployment_test.yaml` had an `equal:` on `ghcr.io/home-operations/tuppr:0.0.0`).

## Verification

| Gate | Result |
| --- | --- |
| `mise run helm-lint` | pass — 1 chart linted, 0 failed (pre-existing `[INFO] icon is recommended`) |
| `mise run helm-unittest` | pass — 5 suites, 20 tests, 0 failures |
| `mise run generate-check` | pass — no drift; generated README/schema in sync |
| `mise run helm-template` | pass — renders with default values |
| lefthook pre-commit (`format-json`, `format-yaml`, `generate`) | pass — no further changes; the yaml formatter preserves the annotation comments |

## Note

`release-please-config.json` picked up an incidental one-line reformat of the pre-existing `exclude-paths` array. That is the repo's own oxfmt pre-commit hook collapsing it to `printWidth: 100`; the file had drifted from that config and touching it re-applies the formatter. My `extra-files` block exceeds the print width so oxfmt keeps it expanded.
