### PR TITLE
fix(sink): append route params without parsing the target url

### DIFF
--- a/internal/sink/apprise.go
+++ b/internal/sink/apprise.go
@@ -2,9 +2,9 @@ package sink
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 
 	apprise "github.com/unraid/apprise-go"
@@ -22,10 +22,7 @@ func (appriseNotifier) Send(ctx context.Context, targetURL, body, title string, 
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	full, err := mergeQuery(targetURL, params)
-	if err != nil {
-		return err
-	}
+	full := mergeQuery(targetURL, params)
 	a := apprise.New()
 	if err := a.Add(full); err != nil {
 		// A bad URL/scheme won't fix itself on retry. Like Send below, the error
@@ -55,35 +52,34 @@ func (appriseNotifier) Send(ctx context.Context, targetURL, body, title string, 
 // strip credential-bearing target URLs that apprise-go echoes in its errors.
 func redactURLs(text string, urls ...string) string {
 	for _, u := range urls {
-		if u != "" {
-			text = strings.ReplaceAll(text, u, "<redacted-url>")
+		if u == "" {
+			continue
 		}
+		text = strings.ReplaceAll(text, u, "<redacted-url>")
+		// url.Error embeds the URL %q-quoted; when quoting escapes a character
+		// the literal replacement above can't match, so strip that form too.
+		text = strings.ReplaceAll(text, strconv.Quote(u), `"<redacted-url>"`)
 	}
 	return text
 }
 
-// mergeQuery URL-encodes params into rawURL's query (params override existing
-// keys). Provider auth/host live in rawURL and are never touched.
-func mergeQuery(rawURL string, params map[string]string) (string, error) {
+// mergeQuery URL-encodes params and appends them to rawURL's query. The URL is
+// never parsed: apprise schemes carry authorities net/url rejects (a tgram://
+// bot token's colon reads as an invalid port), and apprise-go's own parser
+// resolves a repeated key last-wins, so appended params override existing keys.
+func mergeQuery(rawURL string, params map[string]string) string {
 	if len(params) == 0 {
-		return rawURL, nil
+		return rawURL
 	}
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		// url.Parse returns a *url.Error that embeds the raw (credential-bearing)
-		// URL; unwrap to the bare cause so the URL never reaches logs.
-		var ue *url.Error
-		if errors.As(err, &ue) {
-			err = ue.Err
-		}
-		return "", Permanent(fmt.Errorf("apprise: parse target url: %w", err))
-	}
-	q := u.Query()
+	q := url.Values{}
 	for k, v := range params {
 		q.Set(k, v)
 	}
-	u.RawQuery = q.Encode()
-	return u.String(), nil
+	sep := "?"
+	if strings.Contains(rawURL, "?") {
+		sep = "&"
+	}
+	return rawURL + sep + q.Encode()
 }
 
 // appriseSink relays to an apprise target through the Notifier seam.

--- a/internal/sink/sink_test.go
+++ b/internal/sink/sink_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	apprise "github.com/unraid/apprise-go"
+
 	"github.com/home-operations/chaski/internal/config"
 )
 
@@ -67,16 +69,29 @@ func TestAppriseSinkPermanentNotRetried(t *testing.T) {
 }
 
 func TestMergeQuery(t *testing.T) {
-	got, err := mergeQuery("pover://u@t/?sound=pushover", map[string]string{"priority": "2"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	got := mergeQuery("pover://u@t/?sound=pushover", map[string]string{"priority": "2"})
 	if !strings.Contains(got, "priority=2") || !strings.Contains(got, "sound=pushover") {
 		t.Errorf("merged url = %q, want both priority and sound", got)
 	}
+	// A tgram:// bot token carries a colon in the host, which net/url rejects
+	// as an invalid port; the URL must pass through untouched.
+	got = mergeQuery("tgram://123456789:AAEfake/104243855", map[string]string{"format": "html"})
+	if got != "tgram://123456789:AAEfake/104243855?format=html" {
+		t.Errorf("merged tgram url = %q", got)
+	}
 	// No params → unchanged.
-	if got, _ := mergeQuery("pover://u@t/", nil); got != "pover://u@t/" {
+	if got := mergeQuery("pover://u@t/", nil); got != "pover://u@t/" {
 		t.Errorf("empty params changed url: %q", got)
+	}
+}
+
+// TestMergeQueryTelegramAcceptedByApprise pins the seam with apprise-go: its
+// token validation requires the full id:hash token in the tgram:// host, so a
+// merged URL must keep that form intact for Add to accept it.
+func TestMergeQueryTelegramAcceptedByApprise(t *testing.T) {
+	full := mergeQuery("tgram://123456789:AAEfake/104243855", map[string]string{"format": "html"})
+	if err := apprise.New().Add(full); err != nil {
+		t.Fatalf("apprise rejected merged url: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

`mergeQuery` no longer runs the apprise target URL through `net/url.Parse`; it URL-encodes the route's `params` and appends them to the raw URL. apprise-go's parser resolves repeated query keys last-wins, so the params-override-existing-keys semantics are unchanged.

## Why

apprise URLs are not standard URLs. A `tgram://` bot token carries a colon in the host (`tgram://123456789:hash/chatID`), which `net/url` rejects as an invalid port, so any telegram route with `params` (e.g. `format: html`) failed permanently. apprise-go v0.3.0's token-format validation (#104) simultaneously closed the old `tgram://botID/hash/chatID` split workaround: its `host` rule requires the full `id:hash` form. Details in #111.

Not parsing the URL at all also sidesteps the other apprise authority shapes `net/url` mishandles (`rocket://` webhooks with a slash in the authority, multi-`@` userinfo), and stops a `ParseQuery` round-trip from mangling apprise's `+`/`-`/`:` prefixed query keys.

The malformed-URL error now surfaces from apprise-go's `Add`, whose `url.Error` embeds the URL %q-quoted; `redactURLs` now also strips that quoted form so a credential-bearing URL still can't reach logs (pinned by the existing `TestNotifierParseErrorOmitsURL`).

## Testing

- `TestMergeQuery` covers the tgram colon-in-host form passing through intact
- `TestMergeQueryTelegramAcceptedByApprise` pins the seam end-to-end: the merged URL must pass apprise-go's actual token validation in `Add`
- `mise run test` (with `-race`), `mise run lint`, `mise run vet` all pass

Fixes #111