### PR TITLE
fix(chart): keep the routes example out of the targets schema description

### DIFF
--- a/charts/chaski/values.schema.json
+++ b/charts/chaski/values.schema.json
@@ -157,7 +157,7 @@
           "type": "integer"
         },
         "targets": {
-          "description": "  alertmanager:\n    target: pushover\n    whenExpr: 'payload.status == \"firing\"'\n    title: '🔥 {{ .payload.commonLabels.alertname }}'\n    message: '{{ .payload.commonAnnotations.summary }}'\n    params: { priority: '2' }\nTarget (sink) definitions, keyed by name. Each is exactly one of `apprise:` or `http:`. Credentials belong in `{{ env \"VAR\" }}` references resolved from the environment (see `auth`/`envFrom`), never inline.",
+          "description": "Target (sink) definitions, keyed by name. Each is exactly one of `apprise:` or `http:`. Credentials belong in `{{ env \"VAR\" }}` references resolved from the environment (see `auth`/`envFrom`), never inline.",
           "required": [],
           "title": "targets",
           "type": "object"

--- a/charts/chaski/values.yaml
+++ b/charts/chaski/values.yaml
@@ -82,6 +82,7 @@ config:
   #     title: '🔥 {{ .payload.commonLabels.alertname }}'
   #     message: '{{ .payload.commonAnnotations.summary }}'
   #     params: { priority: '2' }
+
   # -- Target (sink) definitions, keyed by name. Each is exactly one of `apprise:` or `http:`. Credentials belong in `{{ env "VAR" }}` references resolved from the environment (see `auth`/`envFrom`), never inline.
   targets: {}
   #   pushover:


### PR DESCRIPTION
Same fix as home-operations/gatus-sidecar#170: helm-schema attaches a commented example block to the *next* key's description in `values.schema.json`, which surfaces as hover docs in editors consuming the schema. One instance here: the alertmanager route example leaked into `config.targets`.

A blank line after the example block stops helm-schema from carrying it forward. Verified with a schema-wide scan (no leaked descriptions remain); chart README and config.schema.json are unchanged, `helm unittest` 20/20, `helm lint` clean.
