### PR TITLE
fix: drop UPX compression, packed binaries segfault (upx/upx#18902)

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -41,11 +41,6 @@ jobs:
           experimental: true
           install_args: --locked
 
-      - name: Install UPX
-        uses: crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368 # v4.0.0
-        with:
-          install-only: true
-
       # Keyed per GOOS: GOCACHE entries differ per target. cache-poisoning
       # rationale in .github/zizmor.yml.
       - name: Cache Go build outputs

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,11 +37,6 @@ archives:
         formats:
           - zip
 
-upx:
-  - enabled: true
-    compress: best
-    lzma: true
-
 checksum:
   algorithm: sha256
   split: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ ARG TARGETARCH
 ARG VERSION=dev
 ARG REVISION=dev
 
-# upx (build stage only) compresses the final binary to shrink the image.
-RUN apk add --no-cache upx
-
 WORKDIR /workspace
 COPY go.mod go.sum ./
 RUN go mod download
@@ -25,8 +22,6 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
     go build -trimpath \
     -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION}" \
     -o chaski ./cmd/chaski
-
-RUN upx --best --lzma chaski
 
 # ---- Runtime --------------------------------------------------------------
 # distroless/static:nonroot — the fleet-standard runtime base for our static


### PR DESCRIPTION
## Overview

Removes UPX compression from the container image build and the goreleaser release archives, following home-operations/flate#935.

UPX has an unfixed stub bug ([upx/upx#18902](https://github.com/upx/upx/issues/18902), [discussion #958](https://github.com/upx/upx/discussions/958)) that segfaults packed binaries depending on the size of the process environment. The stub's handoff in `amd64-linux.elf-fold.S` lands one qword high when the environment is large, so the jump target is an `envp` string pointer and the process faults on NX before the Go runtime exists to report anything: exit 139, no stdout, no stderr, no traceback. It depends on argv/envp layout rather than the machine, so it presents as flaky, and adding or removing a single environment variable flips it.

`upx --best --lzma` was a fleet convention, so every UPX-packed Go binary in the org is exposed; flate is just where it surfaced.

## Changes

- Dockerfile: drop the `apk add upx` and `upx --best --lzma` steps from the build stage.
- `.goreleaser.yaml`: drop the `upx:` block.
- `.github/workflows/goreleaser.yaml`: drop the now unused `Install UPX` step.

## Notes

- The Go build itself is untouched; this only removes the post-build packing step.
- Image/binary size will grow (flate went from 15.7 MB packed to 73.9 MB unpacked). Dropping only `--lzma` would not help, the defect is in the stub's environment handling, not the compressor.
